### PR TITLE
Fixing adding lines feature in report

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/domain/Domain.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/domain/Domain.kt
@@ -57,7 +57,7 @@ abstract class Domain<T : Comparable<T>>(val length: Int? = null) {
   /**
    * Codes that this domain can take
    */
-  var domainCode = DomainCode<T>()
+  var domainCode = DomainCode<T>(this::class.java.simpleName)
 }
 
 /**

--- a/galite-core/src/main/kotlin/org/kopi/galite/domain/DomainCode.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/domain/DomainCode.kt
@@ -20,7 +20,7 @@ package org.kopi.galite.domain
 /**
  * Represents the codes that a domain can take
  */
-class DomainCode<T : Comparable<T>> {
+class DomainCode<T : Comparable<T>>(private val name: String) {
 
   /**
    * Sets a mapping between the values that the domain can take
@@ -30,6 +30,9 @@ class DomainCode<T : Comparable<T>> {
    * @param value the value
    */
   operator fun set(text: String, value: T) {
+    if(text in codes.keys) {
+      throw RuntimeException("$text already exists in domain $name")
+    }
     codes[text] = value
   }
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/report/Line.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/report/Line.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2013-2020 kopiLeft Services SARL, Tunis TN
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.kopi.galite.visual.report
+
+import org.kopi.galite.visual.field.Field
+
+/**
+ * A data line of a [Report].
+ *
+ * @param reportFields the fields that exists in the report.
+ */
+class Line(private val reportFields: MutableList<Field<*>>) {
+  /** A report data line */
+  val reportLine = mutableMapOf<Field<*>, Any>()
+
+  /**
+   * Sets a mapping between the values that the domain can take
+   * and a corresponding text to be displayed in a [Field].
+   *
+   * @param field the field.
+   * @param value the field's value.
+   */
+  operator fun <T: Comparable<T>> set(field: Field<T>, value: T) {
+    if(field in reportFields) {
+      reportLine.putIfAbsent(field, value)
+    }
+  }
+}

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/report/Report.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/report/Report.kt
@@ -24,16 +24,16 @@ import org.kopi.galite.visual.field.Field
  * Represents a report that contains fields [fields] and displays a table of [lines].
  */
 open class Report {
-  /** Report's fields */
+  /** Report's fields. */
   val fields = mutableListOf<Field<*>>()
-  /** Report's data lines */
-  private val lines = mutableListOf<MutableMap<Field<*>, Any>>()
+  /** Report's data lines. */
+  private val lines = mutableListOf<Line>()
 
   /**
    * creates and returns a field. It uses [init] method to initialize the field.
    *
-   * @param domain  the domain of the field
-   * @param init    initialization method
+   * @param domain  the domain of the field.
+   * @param init    initialization method.
    * @return a field.
    */
   fun <T: Comparable<T>> field(domain: Domain<T>, init: Field<T>.() -> Unit) : Field<T> {
@@ -44,40 +44,27 @@ open class Report {
   }
 
   /**
-   * Sets a mapping between the values that the domain can take
-   * and a corresponding text to be displayed in a [Field].
-   *
-   * @param field the field
-   * @param value the field's value
-   */
-  operator fun <T: Comparable<T>> set(field: Field<T>, value: T) {
-    if(field in fields) {
-      lines.last().putIfAbsent(field, value)
-    }
-  }
-
-  /**
    * Adds a line to the report.
    *
-   * @param init initializes the line with values
+   * @param init initializes the line with values.
    */
-  fun add(init: Report.() -> Unit) {
-    val map = mutableMapOf<Field<*>, Any>()
-    lines.add(map)
-    init()
+  fun add(init: Line.() -> Unit) {
+    val line = Line(fields)
+    line.init()
+    lines.add(line)
   }
 
   /**
    * Returns line number [lineNumber].
    *
-   * @param lineNumber line's number
+   * @param lineNumber line's number.
    */
-  fun getLine(lineNumber: Int): MutableMap<Field<*>, Any> = lines[lineNumber]
+  fun getLine(lineNumber: Int): MutableMap<Field<*>, Any> = lines[lineNumber].reportLine
 
   /**
    * Returns lines of data for a specific [field].
    *
-   * @param field the field
+   * @param field the field.
    */
-  fun getLinesForField(field: Field<*>) = lines.map { it[field] }
+  fun getLinesForField(field: Field<*>) = lines.map { it.reportLine[field] }
 }

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/DomainTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/DomainTests.kt
@@ -141,6 +141,8 @@ class DomainTests {
 
   /**
    * Tests Domain of a type code with redundant code.
+   *
+   * Fails if there is a redundant code
    */
   @Test
   fun domainRedundantCodeTest() {
@@ -153,13 +155,9 @@ class DomainTests {
       }
     }
 
-    // Creating a field with the domain IntTestType
-    val field = Field(IntTestType())
-
-    // test code values
-    val codes = field.getCodes()
-    assertEquals(2, codes!!.size)
-    assertEquals(7, codes["cde1"])
-    assertEquals(2, codes["cde2"])
+    // Creating the domain IntTestType
+    assertFailsWith<RuntimeException> {
+      IntTestType()
+    }
   }
 }


### PR DESCRIPTION
Allowed syntax:

````Kotlin
      add {
        this[field1] = "test1"
        this[field2] = 64L
      }
````