### PR TITLE
Support list domain

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/domain/CodeDomain.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/domain/CodeDomain.kt
@@ -15,13 +15,31 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-plugins {
-  kotlin("jvm") apply true
-}
+package org.kopi.galite.domain
 
-val exposedVersion = "0.26.2"
+/**
+ * Represents a domain of type code
+ */
+class CodeDomain<T : Comparable<T>>(private val name: String): Domain<T>() {
 
-dependencies {
-  // Exposed dependencies
-  api("org.jetbrains.exposed", "exposed-core", exposedVersion)
+  /**
+   * Sets a mapping between the values that the domain can take
+   * and a corresponding text to be displayed in a field.
+   *
+   * @param text the text
+   * @param value the value
+   */
+  operator fun set(text: String, value: T) {
+    if(text in codes.keys) {
+      throw RuntimeException("$text already exists in domain $name")
+    }
+    codes[text] = value
+  }
+
+  /**
+   * Mapping of all values that a domain can take
+   */
+  val codes: MutableMap<String, T> = mutableMapOf()
+
+  override val type = this
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/domain/ListDomain.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/domain/ListDomain.kt
@@ -17,27 +17,53 @@
 
 package org.kopi.galite.domain
 
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.Query
+
 /**
- * Represents the codes that a domain can take
+ * Represents a domain of type list
  */
-class DomainCode<T : Comparable<T>>(private val name: String) {
+class ListDomain<T : Comparable<T>>(private val name: String): Domain<T>() {
+  var query: Query? = null
 
   /**
    * Sets a mapping between the values that the domain can take
-   * and a corresponding text to be displayed in a [Field].
+   * and a corresponding text to be displayed in a field.
    *
    * @param text the text
    * @param value the value
    */
-  operator fun set(text: String, value: T) {
-    if(text in codes.keys) {
+  operator fun <V: Comparable<V>> set(text: String, value: Column<V>) {
+    if(text in list.keys) {
       throw RuntimeException("$text already exists in domain $name")
     }
-    codes[text] = value
+    list[text] = value
   }
 
   /**
    * Mapping of all values that a domain can take
    */
-  val codes: MutableMap<String, T> = mutableMapOf()
+  val list: MutableMap<String, Any> = mutableMapOf()
+
+  /**
+   * Transforms values in capital letters.
+   */
+  fun Domain<String>.convertUpper() {
+    convertUpper = true
+  }
+
+  /**
+   * Applies a transformation on the value.
+   *
+   * @param value passed value
+   * @return value after transformation
+   */
+  override fun applyConvertUpper(value: String): String? = when {
+    !convertUpper -> value
+    convertUpper -> value.toUpperCase()
+    else -> null
+  }
+
+  override val type = this
+  var convertUpper = false
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/field/Field.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/field/Field.kt
@@ -62,22 +62,9 @@ class Field<T : Comparable<T>>(val domain: Domain<T>? = null) {
   }
 
   /**
-   * Applies a transformation on the value.
-   *
-   * @param value passed value
-   * @return value after transformation
+   * returns list of values that can this field get.
    */
-  fun applyTransformation(value: T): Any? = when {
-    domain == null -> value
-    domain.transformation == null -> value
-    domain.transformation == Transformation.TransfomationType.CONVERT_UPPER -> (value as String).toUpperCase()
-    else -> null
-  }
-
-  /**
-   * returns list of code values that can this field get.
-   */
-  fun getCodes(): MutableMap<String, T>? {
-    return domain?.domainCode?.codes
+  fun getValues(): MutableMap<String, *>? {
+    return domain?.getValues()
   }
 }

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/CodeDomainTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/CodeDomainTests.kt
@@ -19,9 +19,7 @@ package org.kopi.galite.tests.domain
 
 import org.junit.Test
 import org.kopi.galite.domain.Domain
-import org.kopi.galite.domain.DomainType
 import org.kopi.galite.visual.field.Field
-import org.kopi.galite.visual.field.Transformation.convertUpper
 import org.kopi.galite.visual.exceptions.InvalidValueException
 
 import kotlin.test.assertEquals
@@ -30,9 +28,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Contains tests of domain creation and manipulation
+ * Contains tests of code-domain creation and manipulation
  */
-class DomainTests {
+class CodeDomainTests {
 
   /**
    * Tests the creation of a simple domain with length
@@ -44,7 +42,7 @@ class DomainTests {
   fun simpleDomainWithLengthTest() {
     // Declaration of the domain with length
     class StringTestType : Domain<String>(5) {
-      override val values: DomainType = code {
+      override val type = code {
         this["cde1"] = "1"
       }
     }
@@ -71,7 +69,7 @@ class DomainTests {
   fun domainWithCheckTest() {
     // Declaration of the domain with length
     class StringTestType(val param: String) : Domain<String>(5) {
-      override val values: DomainType = code {
+      override val type = code {
         this["cde1"] = "1"
       }
       override val check = { value: String ->
@@ -93,50 +91,26 @@ class DomainTests {
   }
 
   /**
-   * Tests the creation of a domain with check
-   *
-   * succeed if the is converted to uppercase.
-   * fails otherwise.
-   */
-  @Test
-  fun domainWithConvertUpperTest() {
-    // Declaration of the domain with length
-    class StringTestType : Domain<String>(5) {
-      override val values: DomainType = code {
-        this["cde1"] = "1"
-      }
-      override val transformation = convertUpper()
-    }
-
-    // Creating a field with the domain StringTestType
-    val field = Field(StringTestType())
-
-    // test converted value
-    val convertedToUpper = field.applyTransformation("Abcdef")
-    assertEquals("ABCDEF", convertedToUpper)
-  }
-
-  /**
    * Tests the creation of a domain of a type code.
    */
   @Test
   fun domainCodeTest() {
     // Declaration of the domain with codes
     class IntTestType : Domain<Long>(5) {
-      override val values = code {
-        this["cde1"] = 1
-        this["cde2"] = 2
+      override val type = code {
+        this["cde1"] = 1L
+        this["cde2"] = 2L
       }
     }
 
-    // Creating a field with the domain IntTestType
-    val field = Field(IntTestType())
+    // Creating an instance of the domain IntTestType
+    val domain = IntTestType()
 
     // test code values
-    val codes = field.getCodes()
-    assertEquals(2, codes!!.size)
-    assertEquals(1, codes["cde1"])
-    assertEquals(2, codes["cde2"])
+    val codes = domain.getValues()
+    assertEquals(2, codes.size)
+    assertEquals(1L, codes["cde1"])
+    assertEquals(2L, codes["cde2"])
   }
 
   /**
@@ -148,10 +122,10 @@ class DomainTests {
   fun domainRedundantCodeTest() {
     // Declaration of the domain with codes
     class IntTestType : Domain<Long>(5) {
-      override val values = code {
-        this["cde1"] = 1
-        this["cde2"] = 2
-        this["cde1"] = 7
+      override val type = code {
+        this["cde1"] = 1L
+        this["cde2"] = 2L
+        this["cde1"] = 7L
       }
     }
 

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/ListDomainTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/domain/ListDomainTests.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2013-2020 kopiLeft Services SARL, Tunis TN
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.kopi.galite.tests.domain
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.selectAll
+import org.junit.Test
+import org.kopi.galite.domain.Domain
+import kotlin.test.assertEquals
+
+/**
+ * Contains tests of list-domain creation and manipulation
+ */
+class ListDomainTests {
+
+  /**
+   * Tests the creation of a simple list domain
+   */
+  @Test
+  fun simpleDomainWithLengthTest() {
+    // Declaration of the domain with length
+    class StringTestType : Domain<String>(20) {
+      override val type = list {
+        query = TestTable.selectAll()
+
+        this["name"] =  TestTable.name
+        this["id"] =    TestTable.id
+      }
+    }
+
+    // Creating an instance of the domain StringTestType
+    val domain = StringTestType()
+
+    // test list values
+    val list = domain.getValues()
+    assertEquals(2, list.size)
+    assertEquals(TestTable.id, list["id"])
+    assertEquals(TestTable.name, list["name"])
+  }
+
+  /**
+   * Tests the creation of a domain with convertUpper.
+   *
+   * succeed if the is converted to uppercase.
+   * fails otherwise.
+   */
+  @Test
+  fun domainWithConvertUpperTest() {
+    // Declaration of the domain with length
+    class StringTestType : Domain<String>(5) {
+      override val type = list {
+        convertUpper()
+
+        query = TestTable.selectAll()
+
+        this["id"] =    TestTable.id
+        this["name"] =  TestTable.name
+      }
+    }
+
+    // Creating an instance of the domain StringTestType
+    val domain = StringTestType()
+
+    // test converted value
+    val convertedToUpper = domain.applyConvertUpper("Abcdef")
+    assertEquals("ABCDEF", convertedToUpper)
+  }
+
+  object TestTable : Table("TestTable") {
+    val id = long("id")
+    val name = varchar("name", length = 20)
+  }
+}

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/visual/report/ReportTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/visual/report/ReportTests.kt
@@ -76,13 +76,13 @@ class ReportTests {
   }
 
   class StringTestType : Domain<String>(5) {
-    override val values = code {
+    override val type = code {
       this["cde1"] = "test1"
     }
   }
 
   class LongTestType : Domain<Long>(5) {
-    override val values = code {
+    override val type = code {
       this["cde1"] = 1
     }
   }


### PR DESCRIPTION
What's in this PR:
- List Domain syntax:
````Kotlin
class StringTestType : Domain<String>(5) {
      override val type = list {
        convertUpper()

        query = TestTable.selectAll()

        this["id"] =    TestTable.id
        this["name"] =  TestTable.name
      }
    }
````

- to define domain type use `override val values` instead of `override val type`

- `convertUpper()` is defined only in `ListDomain`