### PR TITLE
Galite domain : Fixing a bug related to the type DATETIME of GaliteDomain [APPS-01MC] 

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/domain/Domain.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/domain/Domain.kt
@@ -180,7 +180,7 @@ open class Domain<T>(val width: Int? = null,
         Month::class -> VMonthField(block.buffer)
         Week::class -> VWeekField(block.buffer)
         org.joda.time.LocalTime::class, LocalTime::class -> VTimeField(block.buffer)
-        Instant::class, LocalDateTime::class, DateTime::class -> VTimestampField(block.buffer)
+        Instant::class, LocalDateTime::class, DateTime::class -> VTimestampField(block.buffer, kClass)
         Image::class -> VImageField(block.buffer, width!!, height!!)
         else -> {
           if(this@Domain is TEXT) {

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VField.kt
@@ -22,9 +22,9 @@ import java.awt.Color
 import java.io.InputStream
 import java.math.BigDecimal
 import java.sql.SQLException
-import java.time.temporal.Temporal
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.temporal.Temporal
 
 import javax.swing.event.EventListenerList
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VField.kt
@@ -22,7 +22,7 @@ import java.awt.Color
 import java.io.InputStream
 import java.math.BigDecimal
 import java.sql.SQLException
-import java.time.Instant
+import java.time.temporal.Temporal
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -1099,7 +1099,7 @@ abstract class VField protected constructor(width: Int, height: Int) : VConstant
    * Warning:   This method will become inaccessible to users in next release
    *
    */
-  fun setTimestamp(v: Instant?) {
+  fun setTimestamp(v: Temporal?) {
     setTimestamp(block!!.currentRecord, v)
   }
 
@@ -1210,7 +1210,7 @@ abstract class VField protected constructor(width: Int, height: Int) : VConstant
    * Warning:   This method will become inaccessible to users in next release
    *
    */
-  open fun setTimestamp(r: Int, v: Instant?) {
+  open fun setTimestamp(r: Int, v: Temporal?) {
     throw InconsistencyException()
   }
 
@@ -1329,7 +1329,7 @@ abstract class VField protected constructor(width: Int, height: Int) : VConstant
    * Warning:   This method will become inaccessible to users in next release
    *
    */
-  fun getTimestamp(): Instant? = getTimestamp(block!!.currentRecord)
+  fun getTimestamp(): Temporal? = getTimestamp(block!!.currentRecord)
 
   /**
    * Returns the field value of the current record as a time value.
@@ -1476,7 +1476,7 @@ abstract class VField protected constructor(width: Int, height: Int) : VConstant
    * Warning:   This method will become inaccessible to users in next release
    *
    */
-  open fun getTimestamp(r: Int): Instant? {
+  open fun getTimestamp(r: Int): Temporal? {
     throw InconsistencyException()
   }
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.time.temporal.Temporal
 import java.util.Locale
 import java.util.StringTokenizer
@@ -40,7 +41,6 @@ import org.kopi.galite.visual.Message
 import org.kopi.galite.visual.MessageCode
 import org.kopi.galite.visual.VException
 import org.kopi.galite.visual.VlibProperties
-import java.time.temporal.ChronoUnit
 
 class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VField(10 + 1 + 8, 1) {
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.temporal.Temporal
 import java.util.Locale
 import java.util.StringTokenizer
 
@@ -40,12 +41,12 @@ import org.kopi.galite.visual.MessageCode
 import org.kopi.galite.visual.VException
 import org.kopi.galite.visual.VlibProperties
 
-class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
+class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VField(10 + 1 + 8, 1) {
 
   // ----------------------------------------------------------------------
   // DATA MEMBERS
   // ----------------------------------------------------------------------
-  private var value: Array<Instant?> = arrayOfNulls(2 * bufferSize)
+  private var value: Array<Temporal?> = arrayOfNulls(2 * bufferSize)
 
   override fun hasAutofill(): Boolean = true
 
@@ -95,12 +96,13 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
     }
   }
 
-  internal fun parseTimestamp(s: String): Instant {
+  internal fun parseTimestamp(s: String): Temporal {
     val timestamp = s.split("[ T]".toRegex(), 2)
     val date = parseDate(timestamp[0])
     val time = parseTime(timestamp[1])
 
-    return Timestamp.valueOf("$date $time").toInstant()
+    return if(kClass == LocalDateTime::class ) Timestamp.valueOf("$date $time").toLocalDateTime()
+           else Timestamp.valueOf("$date $time").toInstant()
   }
 
   private fun parseDate(s: String): String {
@@ -280,7 +282,7 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
   /**
    * Sets the field value of given record to a timestamp value.
    */
-  override fun setTimestamp(r: Int, v: Instant?) {
+  override fun setTimestamp(r: Int, v: Temporal?) {
     if (isChangedUI
             || value[r] == null && v != null
             || value[r] != null && value[r] != v) {
@@ -298,7 +300,7 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
    * Warning:	This method will become inaccessible to kopi users in next release
    */
   override fun setObject(r: Int, v: Any?) {
-    setTimestamp(r, v as? Instant)
+    setTimestamp(r, v as? Temporal)
   }
 
   /**
@@ -323,7 +325,7 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
   /**
    * Returns the field value of given record as a timestamp value.
    */
-  override fun getTimestamp(r: Int): Instant? = getObject(r) as? Instant
+  override fun getTimestamp(r: Int): Temporal? =  if (kClass == LocalDateTime::class) getObject(r) as? LocalDateTime else getObject(r) as? Instant
 
   /**
    * Returns the field value of the current record as an object
@@ -359,7 +361,8 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
     return if (value[r] == null) {
       VConstants.EMPTY_TEXT
     } else {
-      val text = value[r]!!.format()
+      val text = if (kClass == Instant::class) (value[r]!! as Instant).format()
+                 else (value[r]!! as LocalDateTime).format()
       // this is work around to display the timestamp in yyyy-MM-dd hh:mm:ss format
       // The proper way is to change the method Timestamp#toString(Locale) but this
       // will affect the SQL representation of the timestamp value.
@@ -370,7 +373,7 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
   /**
    * Returns the SQL representation of field value of given record.
    */
-  override fun getSqlImpl(r: Int): Instant? = value[r]
+  override fun getSqlImpl(r: Int): Temporal? = value[r]
 
   /**
    * Copies the value of a record to another
@@ -390,13 +393,20 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
   }
 
   /**
+   * Returns the current LocalDateTime or Instant based on kClass
+   */
+  fun getCurrentTimestamp(): Temporal {
+    return if (kClass == LocalDateTime::class) LocalDateTime.now() else Instant.now()
+  }
+
+  /**
    * Returns the data type handled by this field.
    */
-  override fun getDataType(): KClass<*> = Instant::class
+  override fun getDataType(): KClass<*> = kClass!!
 
   override fun fillField(handler: PredefinedValueHandler?): Boolean {
     return if (list == null) {
-      setTimestamp(block!!.activeRecord, Instant.now())
+      setTimestamp(block!!.activeRecord, getCurrentTimestamp())
       true
     } else {
       super.fillField(handler)
@@ -414,7 +424,7 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
         super.enumerateValue(desc)
       }
       isNull(record) -> {
-        setTimestamp(record, Instant.now())
+        setTimestamp(record, getCurrentTimestamp())
       }
       else -> {
         // try to read timestamp
@@ -422,9 +432,9 @@ class VTimestampField(val bufferSize: Int) : VField(10 + 1 + 8, 1) {
           checkType(getText(record))
         } catch (e: VException) {
           // not valid, get now
-          setTimestamp(record, Instant.now())
+          setTimestamp(record, getCurrentTimestamp())
         }
-        setTimestamp(record, getTimestamp(record)?.plusMillis(if (desc) -1 else 1))
+        setTimestamp(record, getCurrentTimestamp())
       }
     }
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
@@ -101,7 +101,7 @@ class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VFie
     val date = parseDate(timestamp[0])
     val time = parseTime(timestamp[1])
 
-    return if(kClass == LocalDateTime::class ) Timestamp.valueOf("$date $time").toLocalDateTime()
+    return if (kClass == LocalDateTime::class ) Timestamp.valueOf("$date $time").toLocalDateTime()
            else Timestamp.valueOf("$date $time").toInstant()
   }
 
@@ -434,7 +434,8 @@ class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VFie
           // not valid, get now
           setTimestamp(record, getCurrentTimestamp())
         }
-        setTimestamp(record, getCurrentTimestamp())
+        setTimestamp(record, if (getTimestamp(record) is Instant) (getTimestamp(record) as? Instant)?.plusMillis(if (desc) -1 else 1)
+                             else (getTimestamp(record) as? LocalDateTime)?.plusNanos(if (desc) -1 else 1))
       }
     }
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VTimestampField.kt
@@ -40,6 +40,7 @@ import org.kopi.galite.visual.Message
 import org.kopi.galite.visual.MessageCode
 import org.kopi.galite.visual.VException
 import org.kopi.galite.visual.VlibProperties
+import java.time.temporal.ChronoUnit
 
 class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VField(10 + 1 + 8, 1) {
 
@@ -435,7 +436,7 @@ class VTimestampField(val bufferSize: Int, val kClass: KClass<*>? = null) : VFie
           setTimestamp(record, getCurrentTimestamp())
         }
         setTimestamp(record, if (getTimestamp(record) is Instant) (getTimestamp(record) as? Instant)?.plusMillis(if (desc) -1 else 1)
-                             else (getTimestamp(record) as? LocalDateTime)?.plusNanos(if (desc) -1 else 1))
+                             else (getTimestamp(record) as? LocalDateTime)?.plus(if (desc) -1 else 1, ChronoUnit.MILLIS))
       }
     }
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/fullcalendar/VFullCalendarBlock.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/fullcalendar/VFullCalendarBlock.kt
@@ -21,6 +21,7 @@ import java.sql.SQLException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.temporal.Temporal
 
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.SortOrder
@@ -43,8 +44,6 @@ import org.kopi.galite.visual.Message
 import org.kopi.galite.visual.MessageCode
 import org.kopi.galite.visual.VException
 import org.kopi.galite.visual.VExecFailedException
-import java.time.LocalDateTime
-import java.time.temporal.Temporal
 
 abstract class VFullCalendarBlock(title: String, buffer: Int, visible: Int) : VBlock(title, buffer, visible) {
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/fullcalendar/VFullCalendarBlock.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/fullcalendar/VFullCalendarBlock.kt
@@ -43,6 +43,8 @@ import org.kopi.galite.visual.Message
 import org.kopi.galite.visual.MessageCode
 import org.kopi.galite.visual.VException
 import org.kopi.galite.visual.VExecFailedException
+import java.time.LocalDateTime
+import java.time.temporal.Temporal
 
 abstract class VFullCalendarBlock(title: String, buffer: Int, visible: Int) : VBlock(title, buffer, visible) {
 
@@ -259,12 +261,12 @@ abstract class VFullCalendarBlock(title: String, buffer: Int, visible: Int) : VB
     return entries
   }
 
-  fun openForEdit(startDateTime: Instant, endDateTime: Instant) {
+  fun openForEdit(startDateTime: Temporal, endDateTime: Temporal) {
     set(startDateTime, endDateTime)
     insertMode()
   }
 
-  internal fun openForEdit(record: Int, newStart: Instant, newEnd: Instant) {
+  internal fun openForEdit(record: Int, newStart: Temporal, newEnd: Temporal) {
     fetchRecordInBlock(record)
     set(newStart, newEnd)
     fullCalendarForm.doNotModal()
@@ -281,7 +283,7 @@ abstract class VFullCalendarBlock(title: String, buffer: Int, visible: Int) : VB
     }
   }
 
-  fun set(startDateTime: Instant, endDateTime: Instant) {
+  fun set(startDateTime: Temporal, endDateTime: Temporal) {
     if (dateField != null) {
       dateField!!.setDate(LocalDate.from(startDateTime))
       fromTimeField!!.setTime(LocalTime.from(startDateTime))

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/calendar/DAbstractFullCalendar.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/calendar/DAbstractFullCalendar.kt
@@ -174,8 +174,8 @@ open class DAbstractFullCalendar protected constructor(protected val model: VFul
 
           check(newStart, newEnd)
           model.openForEdit((it.entry as FullCalendarEntry).record,
-                            newStart.toInstant(),
-                            newEnd.toInstant())
+                            newStart,
+                            newEnd)
         }
       })
     }
@@ -188,8 +188,8 @@ open class DAbstractFullCalendar protected constructor(protected val model: VFul
 
           check(newStart, newEnd)
           model.openForEdit((it.entry as FullCalendarEntry).record,
-                            newStart.toInstant(),
-                            newEnd.toInstant())
+                            newStart,
+                            newEnd)
         }
       })
     }
@@ -202,7 +202,7 @@ open class DAbstractFullCalendar protected constructor(protected val model: VFul
           val end = it.endDateTime
 
           check(start, end)
-          model.openForEdit(start.toInstant(), end.toInstant())
+          model.openForEdit(start, end)
         }
       })
     }

--- a/galite-testing/src/main/kotlin/org/kopi/galite/testing/Field.kt
+++ b/galite-testing/src/main/kotlin/org/kopi/galite/testing/Field.kt
@@ -52,6 +52,9 @@ import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasValue
 import com.vaadin.flow.component.checkbox.Checkbox
 import com.vaadin.flow.component.grid.Grid
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.Temporal
 
 /**
  * Edit a form field.
@@ -85,7 +88,8 @@ private fun <T> FormField<T>.editInMultipleBlock(value: T?, mainWindow: MainWind
 
   when (gridEditorField) {
     is GridEditorTimestampField -> {
-      gridEditorField._value = (value as Instant).format("yyyy-MM-dd HH:mm:ss")
+      gridEditorField._value = if (value is LocalDateTime) value.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                               else (value as Instant).format("yyyy-MM-dd HH:mm:ss")
     }
     is GridEditorTimeField -> {
       gridEditorField._value = (value as LocalTime).format()
@@ -120,7 +124,8 @@ private fun <T> FormField<T>.editInSimpleBlock(value: T?, mainWindow: MainWindow
 
   when {
     (editorField as? TextField)?.getContent() is VTimeStampField -> {
-      editorField._value = (value as Instant).format("yyyy-MM-dd HH:mm:ss")
+      editorField._value = if (value is LocalDateTime) value.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                           else (value as Instant).format("yyyy-MM-dd HH:mm:ss")
     }
     editorField is BooleanField -> {
       val checkbox: Checkbox  = if (value == true) {

--- a/galite-testing/src/main/kotlin/org/kopi/galite/testing/Field.kt
+++ b/galite-testing/src/main/kotlin/org/kopi/galite/testing/Field.kt
@@ -19,7 +19,9 @@ package org.kopi.galite.testing
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 import org.kopi.galite.visual.dsl.form.FormField
 import org.kopi.galite.visual.form.UField
@@ -52,9 +54,6 @@ import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasValue
 import com.vaadin.flow.component.checkbox.Checkbox
 import com.vaadin.flow.component.grid.Grid
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.Temporal
 
 /**
  * Edit a form field.

--- a/galite-tests/src/main/kotlin/org/kopi/galite/tests/ui/vaadin/VUITestBase.kt
+++ b/galite-tests/src/main/kotlin/org/kopi/galite/tests/ui/vaadin/VUITestBase.kt
@@ -17,12 +17,12 @@
 
 package org.kopi.galite.tests.ui.vaadin
 
-import java.time.Instant
+import java.lang.String.format
+import java.time.temporal.Temporal
 
 import org.junit.Before
 import org.junit.BeforeClass
 import org.kopi.galite.testing.waitAndRunUIQueue
-import org.kopi.galite.type.format
 
 import com.github.mvysny.kaributesting.v10.MockVaadin
 import com.github.mvysny.kaributesting.v10.Routes
@@ -78,7 +78,7 @@ open class GaliteVUITestBase: VUITestBase(), TestingLifecycleHook {
     waitAndRunUIQueue(duration)
   }
 
-  fun Instant?.defaultFormat(): String? = this?.let { format("yyyy-MM-dd HH:mm:ss") }
+  fun Temporal?.defaultFormat(): String? = this?.let { format("yyyy-MM-dd HH:mm:ss") }
 
   companion object {
     @BeforeClass

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/Database.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/Database.kt
@@ -17,13 +17,18 @@
 package org.kopi.galite.tests.examples
 
 import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDateTime
 
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.datetime
+import org.jetbrains.exposed.sql.javatime.timestamp
 import org.jetbrains.exposed.sql.nextIntVal
 import org.jetbrains.exposed.sql.transactions.transaction
+
 import org.kopi.galite.tests.database.createDBSchemaTables
 import org.kopi.galite.tests.database.dropDBSchemaTables
 import org.kopi.galite.tests.database.insertIntoUsers
@@ -39,6 +44,8 @@ object Training : Table("TRAINING") {
   val informations = varchar("INFORMATION", 200).nullable()
   val uc = integer("UC").autoIncrement()
   val ts = integer("TS").autoIncrement()
+  val trainDateTimestamp = timestamp("TrainDateTimestamp").nullable()
+  val trainDateTime = datetime("TrainingDateTime").nullable()
 
   override val primaryKey = PrimaryKey(id, name = "PK_TRAINING_ID")
 }
@@ -117,6 +124,8 @@ fun addTraining(name: String, category: Int, amount: BigDecimal, info: String? =
     it[price] = amount
     it[active] = true
     it[informations] = info
+    it[trainDateTimestamp] = Instant.now()
+    it[trainDateTime] = LocalDateTime.now()
   }
 }
 

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/FormExample.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/FormExample.kt
@@ -16,21 +16,14 @@
  */
 package org.kopi.galite.tests.examples
 
+import org.kopi.galite.visual.domain.*
 import java.util.Locale
 
-import org.kopi.galite.visual.domain.BOOL
-import org.kopi.galite.visual.domain.DATE
-import org.kopi.galite.visual.domain.DECIMAL
-import org.kopi.galite.visual.domain.INT
-import org.kopi.galite.visual.domain.MONTH
-import org.kopi.galite.visual.domain.STRING
-import org.kopi.galite.visual.domain.TIME
-import org.kopi.galite.visual.domain.TIMESTAMP
-import org.kopi.galite.visual.domain.WEEK
 import org.kopi.galite.visual.dsl.common.PredefinedCommand
 import org.kopi.galite.visual.dsl.form.Border
 import org.kopi.galite.visual.dsl.form.DictionaryForm
 import org.kopi.galite.visual.dsl.form.Block
+import java.sql.Time
 
 class FormExample : DictionaryForm(title = "Clients", locale = Locale.UK) {
   val action = menu("Action")
@@ -80,6 +73,10 @@ class FormExample : DictionaryForm(title = "Clients", locale = Locale.UK) {
     val timestamp = visit(domain = TIMESTAMP, position = at(7, 1)) {
       label = "Timestamp"
       help = "The Timestamp"
+    }
+    val localdatetime = visit(domain = DATETIME, position = at(7, 2)) {
+      label = "LocalDateTime"
+      help = "The LocalDateTime"
     }
     val time = visit(domain = TIME, position = at(8, 1)) {
       label = "Time"
@@ -146,6 +143,12 @@ class FormExample : DictionaryForm(title = "Clients", locale = Locale.UK) {
       label = "Timestamp"
       help = "The Timestamp"
     }
+
+    val localDateTime = visit(domain = DATETIME, position = at(7, 2)) {
+      label = "localDateTime"
+      help = "The local Date Time"
+    }
+
     val time = visit(domain = TIME, position = at(8, 1)) {
       label = "Time"
       help = "The time"

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/FormExample.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/FormExample.kt
@@ -16,14 +16,13 @@
  */
 package org.kopi.galite.tests.examples
 
-import org.kopi.galite.visual.domain.*
 import java.util.Locale
 
+import org.kopi.galite.visual.domain.*
 import org.kopi.galite.visual.dsl.common.PredefinedCommand
 import org.kopi.galite.visual.dsl.form.Border
 import org.kopi.galite.visual.dsl.form.DictionaryForm
 import org.kopi.galite.visual.dsl.form.Block
-import java.sql.Time
 
 class FormExample : DictionaryForm(title = "Clients", locale = Locale.UK) {
   val action = menu("Action")

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/SimpleForm.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/SimpleForm.kt
@@ -16,9 +16,16 @@
  */
 package org.kopi.galite.tests.examples
 
+import org.junit.Test
+
+import java.time.Instant
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
 import java.util.Locale
 
 import org.kopi.galite.tests.desktop.runForm
+import org.kopi.galite.tests.ui.vaadin.GaliteVUITestBase
+import org.kopi.galite.visual.domain.*
 
 import org.kopi.galite.visual.domain.BOOL
 import org.kopi.galite.visual.domain.DATETIME
@@ -108,6 +115,29 @@ class TraineeshipWithAllFieldTypes : Block("Training", 1, 1) {
     columns(t.informations) {
       priority = 1
     }
+  }
+  val trainDateTimesStamp = visit(domain = TIMESTAMP, at(11,1)) {
+    label = "training Timestamp"
+    columns(t.trainDateTimestamp)
+    value = Instant.now()
+  }
+  val trainDateLocalDateTime = visit(domain = DATETIME, at(12,1)) {
+    label = "training DateTime"
+    columns(t.trainDateTime)
+  }
+}
+
+class testDateTime: GaliteVUITestBase() {
+  val simpleform = SimpleForm()
+  val currentLocalDateTime = LocalDateTime.now()
+  val currentTimestamp = Instant.now()
+
+  @Test
+  fun `test LocalDateTime value`() {
+    simpleform.block.trainDateLocalDateTime.value = currentLocalDateTime
+    simpleform.block.trainDateTimesStamp.value = currentTimestamp
+    assertEquals(simpleform.block.trainDateLocalDateTime.value, currentLocalDateTime)
+    assertEquals(simpleform.block.trainDateTimesStamp.value, currentTimestamp)
   }
 }
 

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/SimpleForm.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/examples/SimpleForm.kt
@@ -20,8 +20,9 @@ import org.junit.Test
 
 import java.time.Instant
 import java.time.LocalDateTime
-import kotlin.test.assertEquals
 import java.util.Locale
+
+import kotlin.test.assertEquals
 
 import org.kopi.galite.tests.desktop.runForm
 import org.kopi.galite.tests.ui.vaadin.GaliteVUITestBase

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/MultipleBlockTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/MultipleBlockTests.kt
@@ -83,9 +83,6 @@ class MultipleBlockTests: GaliteVUITestBase() {
     // Go to the next record
     formExample.salesBlock.editRecord(1)
 
-    println("******** field value localdatetime /******** : ${localdatetime.getModel().getTimestamp(0)}")
-    println("******** current value localdatetime /******** : ${currentLocalDateTime}")
-
     // Check that values are sent to the model
     assertEquals(100, idClt.getModel().getInt(0))
     assertEquals("description", description.getModel().getString(0))

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/MultipleBlockTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/MultipleBlockTests.kt
@@ -19,6 +19,7 @@ package org.kopi.galite.tests.ui.vaadin.block
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 import kotlin.test.assertEquals
@@ -62,23 +63,28 @@ class MultipleBlockTests: GaliteVUITestBase() {
 
     // Enters values to fields
     val currentTimestamp   = Instant.now()
+    val currentLocalDateTime = LocalDateTime.now()
     val currentDate        = LocalDate.now()
     val currentWeek        = Week.now()
     val currentMonth       = Month.now()
     val currentTime        = LocalTime.now()
-    val idClt       = formExample.salesBlock.idClient.edit(100)
-    val description = formExample.salesBlock.description.edit("description")
-    val price       = formExample.salesBlock.price.edit(BigDecimal("100.2"))
-    val active      = formExample.salesBlock.active.edit(true)
-    val date        = formExample.salesBlock.date.edit(currentDate)
-    val month       = formExample.salesBlock.month.edit(currentMonth)
-    val timestamp   = formExample.salesBlock.timestamp.edit(currentTimestamp)
-    val time        = formExample.salesBlock.time.edit(currentTime)
-    val week        = formExample.salesBlock.week.edit(currentWeek)
-    val codeDomain  = formExample.salesBlock.codeDomain.editText("Galite")
+    val idClt              = formExample.salesBlock.idClient.edit(100)
+    val description        = formExample.salesBlock.description.edit("description")
+    val price              = formExample.salesBlock.price.edit(BigDecimal("100.2"))
+    val active             = formExample.salesBlock.active.edit(true)
+    val date               = formExample.salesBlock.date.edit(currentDate)
+    val month              = formExample.salesBlock.month.edit(currentMonth)
+    val timestamp          = formExample.salesBlock.timestamp.edit(currentTimestamp)
+    val localdatetime      = formExample.salesBlock.localdatetime.edit(currentLocalDateTime)
+    val time               = formExample.salesBlock.time.edit(currentTime)
+    val week               = formExample.salesBlock.week.edit(currentWeek)
+    val codeDomain         = formExample.salesBlock.codeDomain.editText("Galite")
 
     // Go to the next record
     formExample.salesBlock.editRecord(1)
+
+    println("******** field value localdatetime /******** : ${localdatetime.getModel().getTimestamp(0)}")
+    println("******** current value localdatetime /******** : ${currentLocalDateTime}")
 
     // Check that values are sent to the model
     assertEquals(100, idClt.getModel().getInt(0))
@@ -88,6 +94,7 @@ class MultipleBlockTests: GaliteVUITestBase() {
     assertEquals(currentDate, date.getModel().getDate(0))
     assertEquals(currentMonth, month.getModel().getMonth(0))
     assertEquals(currentTimestamp.defaultFormat(), timestamp.getModel().getTimestamp(0).defaultFormat())
+    assertEquals(currentLocalDateTime.defaultFormat(), localdatetime.getModel().getTimestamp(0).defaultFormat())
     assertEquals(currentTime.format(), time.getModel().getTime(0).toString())
     assertEquals(currentWeek, week.getModel().getWeek(0))
     assertEquals(1, codeDomain.getModel().getObject(0))
@@ -126,7 +133,7 @@ class MultipleBlockTests: GaliteVUITestBase() {
     formExample.salesBlock.editRecord(1)
 
     val block = formExample.salesBlock.findMultiBlock()
-    block.grid.expectRow(0, "", "", "", "", "", "", "", "", "", "Kotlin")
+    block.grid.expectRow(0, "", "", "", "", "", "", "", "", "", "", "Kotlin")
   }
 
   companion object {

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/SimpleBlockTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/SimpleBlockTests.kt
@@ -19,6 +19,7 @@ package org.kopi.galite.tests.ui.vaadin.block
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 import kotlin.test.assertEquals
@@ -44,7 +45,6 @@ import org.kopi.galite.visual.form.VConstants
 import org.kopi.galite.type.Month
 import org.kopi.galite.type.Week
 import org.kopi.galite.type.format
-import java.time.LocalDateTime
 
 class SimpleBlockTests: GaliteVUITestBase() {
   val testFieldsVisibilityForm = TestFieldsVisibilityForm()

--- a/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/SimpleBlockTests.kt
+++ b/galite-tests/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/block/SimpleBlockTests.kt
@@ -44,6 +44,7 @@ import org.kopi.galite.visual.form.VConstants
 import org.kopi.galite.type.Month
 import org.kopi.galite.type.Week
 import org.kopi.galite.type.format
+import java.time.LocalDateTime
 
 class SimpleBlockTests: GaliteVUITestBase() {
   val testFieldsVisibilityForm = TestFieldsVisibilityForm()
@@ -64,20 +65,22 @@ class SimpleBlockTests: GaliteVUITestBase() {
 
     // Enters values to fields
     val currentTimestamp   = Instant.now()
+    val localdatetime      = LocalDateTime.now()
     val currentDate        = LocalDate.now()
     val currentWeek        = Week.now()
     val currentMonth       = Month.now()
     val currentTime        = LocalTime.now()
-    val idClt       = formExample.salesSimpleBlock.idClt.edit(100)
-    val description = formExample.salesSimpleBlock.description.edit("description")
-    val price       = formExample.salesSimpleBlock.price.edit(BigDecimal("100.2"))
-    val active      = formExample.salesSimpleBlock.active.edit(true)
-    val date        = formExample.salesSimpleBlock.date.edit(currentDate)
-    val month       = formExample.salesSimpleBlock.month.edit(currentMonth)
-    val timestamp   = formExample.salesSimpleBlock.timestamp.edit(currentTimestamp)
-    val time        = formExample.salesSimpleBlock.time.edit(currentTime)
-    val week        = formExample.salesSimpleBlock.week.edit(currentWeek)
-    val codeDomain  = formExample.salesSimpleBlock.codeDomain.editText("Galite")
+    val idClt              = formExample.salesSimpleBlock.idClt.edit(100)
+    val description        = formExample.salesSimpleBlock.description.edit("description")
+    val price              = formExample.salesSimpleBlock.price.edit(BigDecimal("100.2"))
+    val active             = formExample.salesSimpleBlock.active.edit(true)
+    val date               = formExample.salesSimpleBlock.date.edit(currentDate)
+    val month              = formExample.salesSimpleBlock.month.edit(currentMonth)
+    val timestamp          = formExample.salesSimpleBlock.timestamp.edit(currentTimestamp)
+    val localDateTime      = formExample.salesSimpleBlock.localDateTime.edit(localdatetime)
+    val time               = formExample.salesSimpleBlock.time.edit(currentTime)
+    val week               = formExample.salesSimpleBlock.week.edit(currentWeek)
+    val codeDomain         = formExample.salesSimpleBlock.codeDomain.editText("Galite")
 
     // Go to the first field
     formExample.salesSimpleBlock.idClt.click()
@@ -90,6 +93,7 @@ class SimpleBlockTests: GaliteVUITestBase() {
     assertEquals(currentDate, date.getModel().getDate(0))
     assertEquals(currentMonth, month.getModel().getMonth(0))
     assertEquals(currentTimestamp.defaultFormat(), timestamp.getModel().getTimestamp(0).defaultFormat())
+    assertEquals(localdatetime.defaultFormat(), localDateTime.getModel().getTimestamp(0).defaultFormat())
     assertEquals(currentTime.format(), time.getModel().getTime(0).toString())
     assertEquals(currentWeek, week.getModel().getWeek(0))
     assertEquals(1, codeDomain.getModel().getObject(0))


### PR DESCRIPTION
I used the temporal  interface  instead of the Instant class in the VTimeStampField so that we can use the two classes Instant and LocalDateTime that implement this interface.
I also added Unit test. 