### PR TITLE
Galite: allow form creation with tables without ID column 

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/Block.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/Block.kt
@@ -145,11 +145,12 @@ open class Block(val title: String,
    *
    * @param table     the database table
    */
-  fun <T : Table> table(table: T): T {
+  fun <T : Table> table(table: T, id: String? = null): T {
     val formBlockTable = FormBlockTable(table.tableName, table.tableName, table)
 
     tables.add(formBlockTable)
     block.tables.add(formBlockTable.table)
+    if (!id.isNullOrBlank()) block.idsFieldsName.add(id)
 
     return table
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/Block.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/Block.kt
@@ -142,15 +142,21 @@ open class Block(val title: String,
    * Adds the [table] to this block. It refers to certain tables in the database whereby the first table
    * is the one on which the user will work. The remaining tables are the so-called "look-up tables",
    * i.e tables that are associated with the first one.
+   * The [id] represents the column name of the base table to work on.
+   * if not set, means we're using column named "ID".
    *
    * @param table     the database table
+   * @param id        the name of the table's id column
    */
   fun <T : Table> table(table: T, id: String? = null): T {
     val formBlockTable = FormBlockTable(table.tableName, table.tableName, table)
 
     tables.add(formBlockTable)
     block.tables.add(formBlockTable.table)
-    if (!id.isNullOrBlank()) block.idsFieldsName.add(id)
+    if (!id.isNullOrBlank() && id !in table.columns.map { c -> c.name })
+      throw InconsistencyException(" Entered id $id doesn't not belong to table ${table.tableName} !!!")
+    else if (!id.isNullOrBlank() && id != "ID")
+      block.idsFieldsName.add(id)
 
     return table
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
@@ -1977,6 +1977,7 @@ abstract class VBlock(var title: String,
     }
     callProtectedTrigger(VConstants.TRG_POSTDEL)
   }
+  var idsFieldsName = arrayListOf<String>("ID") // We take the table's ID by default as "ID"
 
   /**
    * Searches the field holding the ID of the block's base table.
@@ -1984,7 +1985,7 @@ abstract class VBlock(var title: String,
    */
   val idField: VField
     get() {
-      return getBaseTableField("ID") ?: throw InconsistencyException()
+      return getBaseTableField(idsFieldsName) ?: throw InconsistencyException()
     }
 
   /**
@@ -2005,7 +2006,7 @@ abstract class VBlock(var title: String,
       // laurent : return f even if it's null until we add this field in
       // all the forms. After we can throw an Exception if the field UC
       // of the block base table is not present.
-      return getBaseTableField("UC")
+      return getBaseTableField(arrayListOf("UC"))
     }
 
   /**
@@ -2017,7 +2018,7 @@ abstract class VBlock(var title: String,
       // laurent : return f even if it's null until we add this field in
       // all the forms. After we can throw an Exception if the field UC
       // of the block base table is not present.
-      return getBaseTableField("TS")
+      return getBaseTableField(arrayListOf("TS"))
     }
 
   /**
@@ -2026,10 +2027,10 @@ abstract class VBlock(var title: String,
    * @param     field   the name of the field to search for
    * @return    the field if found, otherwise null
    */
-  protected fun getBaseTableField(field: String): VField? {
+  protected fun getBaseTableField(idsfieldName: ArrayList<String>): VField? {
     for (i in fields.indices) {
       val column = fields[i].lookupColumn(0)
-      if (column != null && column.name == field) {
+      if (column != null && idsfieldName.contains(column.name)) {
         return fields[i]
       }
     }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
@@ -1977,7 +1977,8 @@ abstract class VBlock(var title: String,
     }
     callProtectedTrigger(VConstants.TRG_POSTDEL)
   }
-  var idsFieldsName = arrayListOf<String>("ID") // We take the table's ID by default as "ID"
+
+  var idsFieldsName = arrayListOf("ID") // We take the table's ID by default as "ID"
 
   /**
    * Searches the field holding the ID of the block's base table.
@@ -2024,13 +2025,14 @@ abstract class VBlock(var title: String,
   /**
    * Searches a field of block base table
    *
-   * @param     field   the name of the field to search for
+   * @param     fielsdName   the list of names of table's column of the field to search for
    * @return    the field if found, otherwise null
    */
-  protected fun getBaseTableField(idsfieldName: ArrayList<String>): VField? {
+  protected fun getBaseTableField(fielsdName: ArrayList<String>): VField? {
     for (i in fields.indices) {
       val column = fields[i].lookupColumn(0)
-      if (column != null && idsfieldName.contains(column.name)) {
+
+      if (column != null && fielsdName.contains(column.name)) {
         return fields[i]
       }
     }

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
@@ -145,7 +145,7 @@ class ClientForm : DictionaryForm(title = "Clients", locale = Locale.UK) {
   }
 
   inner class Sales : Block("Sales", 10, 10) {
-    val C = table(Client, "TEST")
+    val C = table(Client, Client.idClt.name)
     val S = table(Purchase)
     val P = table(Product)
 

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
@@ -62,7 +62,7 @@ class ClientForm : DictionaryForm(title = "Clients", locale = Locale.UK) {
   val salesBlock = clientsPage.insertBlock(Sales())
 
   inner class Clients : Block("Clients", 1, 100) {
-    val c = table(Client)
+    val c = table(Client, "TEST")
 
     val idClt = visit(domain = ClientID, position = at(1, 1..2)) {
       label = "ID"
@@ -145,7 +145,7 @@ class ClientForm : DictionaryForm(title = "Clients", locale = Locale.UK) {
   }
 
   inner class Sales : Block("Sales", 10, 10) {
-    val C = table(Client)
+    val C = table(Client, "TEST")
     val S = table(Purchase)
     val P = table(Product)
 
@@ -227,8 +227,8 @@ class ClientForm : DictionaryForm(title = "Clients", locale = Locale.UK) {
     init {
       "Id"      keyOf Client.idClt                                      hasWidth 5
       "Name"    keyOf SqlExpressionBuilder.concat(Client.firstNameClt,
-                                                  stringLiteral(" "),
-                                                  Client.lastNameClt)   hasWidth 76
+        stringLiteral(" "),
+        Client.lastNameClt)   hasWidth 76
       "Age"     keyOf Client.ageClt                                     hasWidth 3
     }
   }

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/database/Tables.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/database/Tables.kt
@@ -22,7 +22,7 @@ import org.jetbrains.exposed.sql.javatime.date
 import org.jetbrains.exposed.sql.javatime.timestamp
 
 object Client : Table("CLIENTS") {
-  val idClt = integer("ID").autoIncrement()
+  val idClt = integer("TEST").autoIncrement()
   val firstNameClt = varchar("FIRSTNAME", 25)
   val lastNameClt = varchar("LASTNAME", 25)
   val addressClt = varchar("ADDRESS", 50)

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/database/Tables.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/database/Tables.kt
@@ -40,7 +40,7 @@ object Purchase: Table("PURCHASE") {
   val id = integer("ID").autoIncrement()
   val idClt = integer("CLIENT").references(Client.idClt)
   val idPdt = integer("PRODUCT").references(Product.idPdt)
-  val quantity = integer("QUANTITY")
+  val quantity = integer("TEST")
 }
 
 object Product : Table("PRODUCTS") {


### PR DESCRIPTION
In this pull request, we added an idsFieldsName variable to use when getting the the base table filed, thus we preserve the existing fonctionality and adapting to use tables without the ID Column 