### PR TITLE
Avoid creating the schemaorg_apache_xmlbeans package containing copies of the *.xsd files [APPS-028O]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,6 @@ subprojects {
     maven {
       url = uri("https://mvnrepository.com/artifact/org.vaadin.addons")
     }
-    mavenLocal()
   }
 
   dependencies {
@@ -81,9 +80,9 @@ allprojects {
           artifactId = project.name
           from(project.components["java"])
           pom {
-            name.set(project.name)
+            configureMavenCentralPom(project)
           }
-         // signPublication(project)
+          signPublication(project)
         }
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ subprojects {
     maven {
       url = uri("https://mvnrepository.com/artifact/org.vaadin.addons")
     }
+    mavenLocal()
   }
 
   dependencies {
@@ -80,9 +81,9 @@ allprojects {
           artifactId = project.name
           from(project.components["java"])
           pom {
-            configureMavenCentralPom(project)
+            name.set(project.name)
           }
-          signPublication(project)
+         // signPublication(project)
         }
       }
     }

--- a/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/generator/FactoryGenerator.kt
+++ b/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/generator/FactoryGenerator.kt
@@ -54,8 +54,6 @@ class FactoryGenerator {
 
     params.baseDir = params.baseDir ?: File(SystemProperties.getProperty("user.dir"))
     val cpResourceLoader = params.classpath?.let { PathResourceLoader(it) }
-    val schemasDir =
-      IOUtil.createDir(params.classesDir!!, "schema" + SchemaTypeSystemImpl.METADATA_PACKAGE_GEN + "/src")
     val errorListener = XmlErrorWatcher(params.errorListener)
     params.resourceLoader = cpResourceLoader
 
@@ -68,7 +66,6 @@ class FactoryGenerator {
                                       cpResourceLoader,
                                       errorListener as MutableCollection<XmlError>,
                                       params.baseDir,
-                                      schemasDir,
                                       params.classpath)
 
     if (errorListener.hasError()) {
@@ -123,7 +120,7 @@ class FactoryGenerator {
     }
 
     val finish = System.currentTimeMillis()
-    println("Time to generate factory classes code: " + ((finish - start).toDouble() / 1000.0) + " seconds")
+    println("\u001B[35mTime to generate factory classe(s) code: " + ((finish - start).toDouble() / 1000.0) + " seconds")
   }
 
   /**

--- a/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/parser/SchemaParser.kt
+++ b/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/parser/SchemaParser.kt
@@ -41,7 +41,6 @@ class SchemaParser {
 		        cpResourceLoader: ResourceLoader?,
 		        outerErrorListener: MutableCollection<XmlError>?,
 		        baseDir: File?,
-		        schemasDir: File?,
 		        classpath: Array<File>?): SchemaTypeSystem {
 		val errorListener = XmlErrorWatcher(outerErrorListener)
 		val state = StscState.start()
@@ -125,7 +124,6 @@ class SchemaParser {
 			options = opts
 			setErrorListener(errorListener)
 			isJavaize = true
-			this.schemasDir = schemasDir
 			baseDir?.let { baseURI = it.toURI() }
 		}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx4g
 #
 group=org.kopi
-version=1.5.3
+version=1.5.3-028O


### PR DESCRIPTION
Avoid creating the schemaorg_apache_xmlbeans package containing copies of the *.xsd files when using the factory generation script.