### PR TITLE
Étudier l'impact de suppression de schemas dir dans le factoryGenerator [APPS-02AH]

### DIFF
--- a/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/generator/FactoryGenerator.kt
+++ b/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/generator/FactoryGenerator.kt
@@ -301,9 +301,6 @@ class FactoryGenerator {
       if (instance.loadSchemaComponents(params)) {
         instance.generateClasses(params)
       }
-
-      val schemaDir = Paths.get("${instance.options.directory ?: instance.options.source}/schemaorg_apache_xmlbeans")
-      schemaDir.toFile().deleteRecursively()
     }
   }
 }

--- a/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/utils/IOUtil.kt
+++ b/galite-util/src/main/kotlin/org/kopi/galite/util/xsdToFactory/utils/IOUtil.kt
@@ -51,6 +51,7 @@ object IOUtil {
    */
   @Throws(FileNotFoundException::class)
   fun createFactoryStream(baseDir: File, name: String, ext: String): OutputStream {
+    createDir(baseDir,null)
     val absolutePath = baseDir.absolutePath
     val factory = File("$absolutePath/$name.$ext")
 


### PR DESCRIPTION
Dans cette branche, nous avons corrigé la régression causée par la branche 028O et supprimé l'opération de suppression inutile du dossier schema org, qui avait déjà été supprimé.