### PR TITLE
Fix : TAB Key action for Galit Enum Fields (VCodeField) [APPS-01X1]

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VCodeField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VCodeField.kt
@@ -149,13 +149,12 @@ abstract class VCodeField(val bufferSize: Int,
           selectedToModel = IntArray(count)
           var j = 0
 
-          while (i < labels.size) {
+          for(i in labels.indices) {
             if (labels[i].lowercase().startsWith(s)) {
-              codes[j] = codes[i]
+              codes[j] = getCodes()[i]
               selectedToModel[j] = i
               j++
             }
-            i++
           }
 
           listDialog = VListDialog(arrayOf(getListColumn()!!), arrayOf(codes))

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/JSUtils.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/JSUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2022 kopiLeft Services SARL, Tunis TN
+ * Copyright (c) 2013-2024 kopiLeft Services SARL, Tunis TN
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,12 +16,12 @@
  */
 package org.kopi.galite.visual.ui.vaadin.base
 
+import org.kopi.galite.visual.ui.vaadin.field.VCodeField
 import org.kopi.galite.visual.ui.vaadin.field.VTimeField
 import org.kopi.galite.visual.ui.vaadin.field.VTimeStampField
 
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.KeyModifier
-import org.kopi.galite.visual.ui.vaadin.field.VCodeField
 
 fun Component.addJSKeyDownListener(shortCuts: MutableMap<String, ShortcutAction<*>>) {
   val jsCall = """

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/JSUtils.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/JSUtils.kt
@@ -21,6 +21,7 @@ import org.kopi.galite.visual.ui.vaadin.field.VTimeStampField
 
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.KeyModifier
+import org.kopi.galite.visual.ui.vaadin.field.VCodeField
 
 fun Component.addJSKeyDownListener(shortCuts: MutableMap<String, ShortcutAction<*>>) {
   val jsCall = """
@@ -62,6 +63,7 @@ fun Component.inputValueExpression(): String {
   return when (this) {
     is VTimeField -> "this.inputElement.value"
     is VTimeStampField -> "this.__datePicker.inputElement.value + ' ' + this.__timePicker.inputElement.value"
+    is VCodeField -> "this.inputElement.value"
     else -> "this.value"
   }
 }


### PR DESCRIPTION
La proposition **VCodeField -> this.$.input.value** n'est pas applicable car la tabulation devient globale, c'est-à-dire qu'elle affecte tous les composants de la fenêtre et du navigateur (boutons de retour, de rafraîchissement, les layouts de Galite, etc.). De plus, l'autocomplétion du texte sous les combobox devient également inopérante. Pour ces raisons, nous allons garder la proposition **VCodeField -> this.inputElement.value.**

On a aussi effectuer les autres changements et valider par  les tests