### PR TITLE
Fix : Allow LEFT JOIN for nullable fields with non nullable fields in Galite forms [APPS-02F2]

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/FormField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/dsl/form/FormField.kt
@@ -175,10 +175,10 @@ open class FormField<T>(internal val block: Block,
   /** list of key columns */
   var keyColumns = mutableListOf<Column<*>>()
 
-  /** used for LEFT OUTER JOIN */
-  fun <T: Column<*>> nullable(column: T): T {
+  /** Used for LEFT OUTER JOIN */
+  fun <V: T?> nullable(column: Column<V>): Column<T> {
     nullableColumns.add(column)
-    return column
+    return column as Column<T>
   }
 
   /**


### PR DESCRIPTION
Currently, the function columns() in Galite forms allows us to join two fields of the same type. However, when needing to do a left join, (function FormField.nullable), we can need to do a left join with the same type but one of them can be nullable. 

This PR adds the possibility to left join a nullable field with a non nullable one in galite forms.