### PR TITLE
Fix : Use Vaadin flow CheckboxGroup component for Boolean field to simplify the field manipulation and fix the focus issues when using the keyboard to browse a form's different fields [APPS-02BL]

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBlock.kt
@@ -991,6 +991,8 @@ abstract class VBlock(var title: String,
     if (target == null) {
       old!!.enter()
       throw VExecFailedException()
+    } else if (target is VBooleanField) {
+      target.focusOnFirst = true
     }
     target.enter()
   }
@@ -1024,6 +1026,8 @@ abstract class VBlock(var title: String,
     if (target == null) {
       old!!.enter()
       throw VExecFailedException()
+    } else if (target is VBooleanField) {
+      target.focusOnFirst = false
     }
     target.enter()
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/form/VBooleanField.kt
@@ -28,6 +28,7 @@ class VBooleanField(bufferSize: Int) : VBooleanCodeField(bufferSize,
                                                          booleanNames,
                                                          booleanCodes,
                                                          true) {
+  var focusOnFirst = true
 
   /**
    * return the name of this field

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
@@ -86,7 +86,6 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
    */
   fun setFocus(focus: Boolean) {
     if (focus) {
-      focusedIndex = 0
       focus()
     } else {
       blur()
@@ -176,6 +175,7 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
    */
   override fun addFocusListener(function: () -> Unit) {
     checkboxGroup.element.addEventListener("focus") {
+      focusedIndex = 0
       function()
     }
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
@@ -15,69 +15,65 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package org.kopi.galite.visual.ui.vaadin.field
 
-import org.kopi.galite.visual.ui.vaadin.base.Styles
-
-import com.vaadin.flow.component.BlurNotifier
 import com.vaadin.flow.component.Component
-import com.vaadin.flow.component.FocusNotifier
-import com.vaadin.flow.component.HasValue
-import com.vaadin.flow.component.checkbox.Checkbox
+import com.vaadin.flow.component.BlurNotifier
+import com.vaadin.flow.component.Focusable
+import com.vaadin.flow.component.KeyNotifier
+import com.vaadin.flow.component.checkbox.CheckboxGroup
 import com.vaadin.flow.component.dependency.CssImport
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+
+import org.kopi.galite.visual.ui.vaadin.base.Styles
 
 /**
  * The boolean field
  *
  * @param trueRepresentation The representation of the true value.
- * @param falseRepresentation The representation of the false false
+ * @param falseRepresentation The representation of the false value
  */
 @CssImport.Container(value = [
   CssImport("./styles/galite/checkbox.css"),
   CssImport(value = "./styles/galite/checkbox.css", themeFor = "vaadin-checkbox")
 ])
-class BooleanField(trueRepresentation: String?, falseRepresentation: String?) : ObjectField<Boolean?>() {
-
-  /**
-   * Sets the boolean field to be mandatory
-   * This will remove to choose the null option
-   * from the two check boxes
-   */
+class BooleanField(val trueRepresentation: String?, val falseRepresentation: String?) : AbstractField<Boolean?>(),
+                                                                                        KeyNotifier,
+                                                                                        BlurNotifier<AbstractField<Boolean?>>
+{
+   // Sets the boolean field to be mandatory.
+   // This will remove to choose the null option from the two check boxes
   var mandatory = false
-
-  private val content: HorizontalLayout = HorizontalLayout()
-
-  private val yes: Checkbox = Checkbox()
-
-  private val no: Checkbox = Checkbox()
-
-  private var forceHiddenVisibility = false
+  // Variable to keep track of the last focused checkbox item
+  private var focusedIndex = 0
+  // Initialize the field checkboxGroup Component
+  private val checkboxGroup: FocusableCheckboxGroup<String> = FocusableCheckboxGroup<String>().apply {
+    label = null
+    // Define the items for true, false, and optionally an empty state
+    setItems(trueRepresentation.orEmpty(), falseRepresentation.orEmpty())
+    value = setOf() // Initialize with no selection
+    addValueChangeListener { event ->
+      // Ensure only one item is selected, or none at all
+      if (event.value.size > 1) {
+        // Keep only the last selected item
+        val lastSelected = event.value
+        lastSelected.remove(event.oldValue.iterator().next())
+        value = setOf(lastSelected.iterator().next())
+      } else if (event.value.isEmpty() && mandatory) {
+        // If mandatory, remove the null option choice
+        value = event.oldValue
+      }
+      // Update internal model and fire change event
+      setModelValue(getBooleanValue(value), true)
+    }
+  }
 
   init {
-    className = Styles.BOOLEAN_FIELD
-    content.className = "k-boolean-field-content"
-    yes.classNames.add("true")
-    no.classNames.add("false")
-    setLabel(trueRepresentation, falseRepresentation)
-    content.add(yes)
-    content.add(no)
-    add(content)
-    yes.addValueChangeListener(::onYesChange)
-    no.addValueChangeListener(::onNoChange)
-    yes.element.style["visibility"] = "hidden"
-    no.element.style["visibility"] = "hidden"
+    // Remove the "Yes" and "No" labels
+    checkboxGroup.setItemLabelGenerator { "" }
+    checkboxGroup.addClassName(Styles.BOOLEAN_FIELD)
 
-    addFocusListener(::onFocus)
-    addBlurListener(::onBlur)
-    content.element.addEventListener("mouseover") {
-      isVisible = true
-    }
-    content.element.addEventListener("mouseout") {
-      if (value == null) {
-        isVisible = false
-      }
-    }
+    add(checkboxGroup)
   }
 
   //---------------------------------------------------
@@ -90,6 +86,7 @@ class BooleanField(trueRepresentation: String?, falseRepresentation: String?) : 
    */
   fun setFocus(focus: Boolean) {
     if (focus) {
+      focusedIndex = 0
       focus()
     } else {
       blur()
@@ -108,141 +105,99 @@ class BooleanField(trueRepresentation: String?, falseRepresentation: String?) : 
     }
   }
 
-  private fun onBlur(event: BlurNotifier.BlurEvent<AbstractField<Boolean?>>) {
-    if (value == null) {
-      isVisible = false
+  /**
+   * Gets the field's boolean value
+   */
+  private fun getBooleanValue(selectedValues: Set<String>): Boolean? {
+    return when {
+      selectedValues.isEmpty()                    -> null
+      selectedValues.contains(trueRepresentation) -> true
+      selectedValues.contains(falseRepresentation) -> false
+      else -> null
     }
   }
-
-  private fun onFocus(event: FocusNotifier.FocusEvent<AbstractField<Boolean?>>) {
-    isVisible = true
-  }
-
-  override fun setParentVisibility(visible: Boolean) {
-    if (value == null) {
-      yes.element.style["visibility"] = "hidden"
-      no.element.style["visibility"] = "hidden"
-      element.classList.remove(Styles.BOOLEAN_FIELD + "-visible")
-    } else {
-      isVisible = visible
-    }
-    forceHiddenVisibility = !visible
-  }
-
-  override fun setVisible(visible: Boolean) {
-    if (!forceHiddenVisibility && visible) {
-      yes.element.style["visibility"] = "visible"
-      no.element.style["visibility"] = "visible"
-      element.classList.add(Styles.BOOLEAN_FIELD + "-visible")
-    } else {
-      yes.element.style["visibility"] = "hidden"
-      no.element.style["visibility"] = "hidden"
-      element.classList.remove(Styles.BOOLEAN_FIELD + "-visible")
-    }
-  }
-
-  override fun isVisible(): Boolean =
-    yes.element.style["visibility"].equals("visible")
-            && no.element.style["visibility"].equals("visible")
-
-  override val isNull: Boolean
-    get() = !yes.value && !no.value
 
   /**
-   * Sets the value of this boolean field.
-   * @param value The field value.
+   * Function to check if the last item is currently focused
+   */
+  private fun isLastItemFocused(currentIndex: Int, itemCount: Int = 2): Boolean {
+    return currentIndex == itemCount
+  }
+
+  /**
+   * Sets the component value from a boolean value
    */
   override fun setValue(value: Boolean?) {
-    when {
-      value == null -> {
-        yes.value = false
-        no.value = false
-      }
-      value -> {
-        yes.value = true
-        no.value = false
-      }
-      else -> {
-        yes.value = false
-        no.value = true
-      }
+    checkboxGroup.value = when (value) {
+      true -> setOf(trueRepresentation)
+      false -> setOf(falseRepresentation)
+      else -> emptySet()
     }
-    handleComponentVisiblity()
   }
 
+  /**
+   * Updates the presentation of this field to display the provided value.
+   */
   override fun setPresentationValue(newPresentationValue: Boolean?) {
-    value = newPresentationValue
+    setValue(newPresentationValue)
   }
 
-  override fun addFocusListener(function: () -> Unit) {
-    yes.addFocusListener {
-      function()
-    }
-    no.addFocusListener {
-      function()
-    }
-  }
+  /**
+   * Checks if the component value is null
+   */
+  override val isNull: Boolean
+    get() = checkboxGroup.value.isEmpty()
 
-  override fun getContent(): Component = content
+  /**
+   * @return the field's checkbox group component
+   */
+  override fun getContent(): Component = checkboxGroup
 
+  /**
+   * Enables the checkbox group component
+   */
   override fun setEnabled(enabled: Boolean) {
     super.setEnabled(enabled)
-    yes.isEnabled = enabled
-    no.isEnabled = enabled
+    checkboxGroup.isEnabled = enabled
   }
 
-  override fun setColor(foreground: String?, background: String?) {
-    // NOT SUPPORTED FOR BOOLEAN FIELDS
-  }
+  /**
+   * @return the boolean value represented by the field
+   */
+  override fun getValue(): Boolean? = getBooleanValue(checkboxGroup.value)
 
-  override fun getValue(): Boolean? =
-          if (!yes.value && !no.value) {
-            null
-          } else {
-            yes.value
-          }
-
+  /**
+   * Checks the boolean field value : No specific actions to execute
+   */
   override fun checkValue(rec: Int) {}
 
-  private fun onYesChange(event: HasValue.ValueChangeEvent<Boolean>) {
-    if (event.isFromClient) {
-      if (event.value) {
-        no.value = false
-      } else if (mandatory && !no.value) {
-        yes.value = true
-      }
+  /**
+   * Adds Custom focus listener for BooleanField
+   */
+  override fun addFocusListener(function: () -> Unit) {
+    checkboxGroup.element.addEventListener("focus") {
+      function()
     }
-    setModelValue(value, event.isFromClient)
-    handleComponentVisiblity()
-  }
-
-  private fun onNoChange(event: HasValue.ValueChangeEvent<Boolean>) {
-    if (event.isFromClient) {
-      if (event.value) {
-        yes.value = false
-      } else if (mandatory && !yes.value) {
-        no.value = true
-      }
-    }
-    setModelValue(value, event.isFromClient)
-    handleComponentVisiblity()
   }
 
   /**
-   * Handles the component visibility according to its value.
+   * Adds custom blur listener for BooleanField : the triggered function is only executed when leaving the field
    */
-  internal fun handleComponentVisiblity() {
-    isVisible = value != null
+  fun addBlurListener(function: () -> Unit) {
+    checkboxGroup.element.addEventListener("focusout") {
+      if (isLastItemFocused(focusedIndex)) {
+        function()
+      } else {
+        focusedIndex++
+      }
+    }
   }
 
-  /**
-   * Sets the tooltip of the checkbox buttons inside the boolean field.
-   *
-   * @param yes The localized label for true value.
-   * @param no The localized label for false value.
-   */
-  fun setLabel(yes: String?, no: String?) {
-    this.yes.element.setProperty("title", yes)
-    this.no.element.setProperty("title", no)
+  // Inner class to encapsulate CheckboxGroup component and make it focusable
+  inner class FocusableCheckboxGroup<T> : CheckboxGroup<T>(), Focusable<CheckboxGroup<T>>, BlurNotifier<CheckboxGroup<T>> {
+    init {
+      // Make the component part of the tab order by setting tab index
+      element.setAttribute("tabindex", "0")
+    }
   }
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
@@ -132,9 +132,9 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
    */
   override fun setValue(value: Boolean?) {
     checkboxGroup.value = when (value) {
-      true -> setOf(trueRepresentation)
+      true  -> setOf(trueRepresentation)
       false -> setOf(falseRepresentation)
-      else -> emptySet()
+      else  -> emptySet()
     }
   }
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
@@ -181,7 +181,7 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
   /**
    * Adds Custom focus listener for BooleanField
    */
-  override fun addFocusListener(focusFunction: () -> Unit) {}
+  override fun addFocusListener(function: () -> Unit) {}
 
   /**
    * Adds custom Key Down listener for BooleanField.
@@ -213,7 +213,8 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
   inner class FocusableCheckboxGroup<T> : CheckboxGroup<T>(), Focusable<CheckboxGroup<T>>, KeyNotifier {
     init {
       // Make the component part of the tab order by setting tab index
-      element.setAttribute("tabindex", "0")
+      // set tabindex to -1 to make the container non-focusable
+      element.setAttribute("tabindex", "-1")
     }
   }
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/field/BooleanField.kt
@@ -50,6 +50,7 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
   var mandatory = false
   // Variable to keep track of the last focused checkbox item
   private var focusedIndex = 0
+  private var focusOnFirst = true
   // Initialize the field checkboxGroup Component
   private val checkboxGroup: FocusableCheckboxGroup<String> = FocusableCheckboxGroup<String>().apply {
     label = null
@@ -88,8 +89,9 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
    * Sets the field focus.
    * @param focus The field focus
    */
-  fun setFocus(focus: Boolean) {
+  fun setFocus(focus: Boolean, focusOnFirst: Boolean) {
     if (focus) {
+      this.focusOnFirst = focusOnFirst
       focus()
     } else {
       blur()
@@ -121,10 +123,12 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
   }
 
   /**
-   * Function to check if the last item is currently focused
+   * Focus on the appropriate checkbox element
    */
-  private fun isLastItemFocused(currentIndex: Int, itemCount: Int = 2): Boolean {
-    return currentIndex == itemCount
+  override fun focus() {
+    focusedIndex = if (focusOnFirst) 0 else 1
+    val focusedCheckbox = checkboxGroup.getChildren().toList()[focusedIndex] as? Checkbox
+    focusedCheckbox?.focus()
   }
 
   /**
@@ -177,12 +181,7 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
   /**
    * Adds Custom focus listener for BooleanField
    */
-  override fun addFocusListener(focusFunction: () -> Unit) {
-    checkboxGroup.element.addEventListener("focus") {
-      focusedIndex = 0
-      focusFunction()
-    }
-  }
+  override fun addFocusListener(focusFunction: () -> Unit) {}
 
   /**
    * Adds custom Key Down listener for BooleanField.
@@ -196,13 +195,13 @@ class BooleanField(val trueRepresentation: String?, val falseRepresentation: Str
           val modifier = event.modifiers.singleOrNull()
 
           if (modifier != null && modifier.name == "SHIFT") {
-            if (focusedIndex <= 1) { gotoPrevious() } else { focusedIndex-- }
+            if (focusedIndex <= 0) { gotoPrevious() } else { focusedIndex-- }
           } else {
-            if (isLastItemFocused(focusedIndex)) { gotoNext() } else { focusedIndex++ }
+            if (focusedIndex >= 1) { gotoNext() } else { focusedIndex++ }
           }
         }
         Key.ENTER, Key.SPACE -> { // Change the value of the currently focused checkbox
-          val checkbox = items.getOrNull(focusedIndex - 1) as? Checkbox
+          val checkbox = items.getOrNull(focusedIndex) as? Checkbox
 
           checkbox?.value = !(checkbox?.value ?: false)
         }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
@@ -54,6 +54,7 @@ class DBooleanField(
   // --------------------------------------------------
   init {
     field.addValueChangeListener(this)
+    field.addFocusListener {}
     field.addBlurListener { gotoNextField() }
     setFieldContent(field)
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
@@ -20,6 +20,7 @@ package org.kopi.galite.visual.ui.vaadin.form
 import com.vaadin.flow.component.AbstractField
 import com.vaadin.flow.component.HasValue
 
+import org.kopi.galite.visual.form.VBooleanField
 import org.kopi.galite.visual.form.VConstants
 import org.kopi.galite.visual.form.VFieldUI
 import org.kopi.galite.visual.ui.vaadin.base.BackgroundThreadHandler.access
@@ -54,7 +55,6 @@ class DBooleanField(
   // --------------------------------------------------
   init {
     field.addValueChangeListener(this)
-    field.addFocusListener {}
     field.addKeyDownListener(gotoNext = { gotoNextField() }, gotoPrevious = { gotoPrevField() })
     setFieldContent(field)
   }
@@ -87,7 +87,7 @@ class DBooleanField(
     } else {
       if (!inside) {
         inside = true
-        enterMe()
+        enterMe((getModel() as? VBooleanField)?.focusOnFirst ?: true)
       }
     }
     super.updateFocus()
@@ -139,9 +139,9 @@ class DBooleanField(
   /**
    * Gets the focus to this field.
    */
-  private fun enterMe() {
+  private fun enterMe(focusOnFirst: Boolean) {
     access(currentUI) {
-      field.setFocus(true)
+      field.setFocus(true, focusOnFirst)
     }
   }
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
@@ -55,7 +55,7 @@ class DBooleanField(
   init {
     field.addValueChangeListener(this)
     field.addFocusListener {}
-    field.addBlurListener { gotoNextField() }
+    field.addKeyDownListener(gotoNext = { gotoNextField() }, gotoPrevious = { gotoPrevField() })
     setFieldContent(field)
   }
 

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
@@ -17,14 +17,13 @@
  */
 package org.kopi.galite.visual.ui.vaadin.form
 
-import org.kopi.galite.visual.form.UTextField
+import com.vaadin.flow.component.AbstractField
+import com.vaadin.flow.component.HasValue
+
 import org.kopi.galite.visual.form.VConstants
 import org.kopi.galite.visual.form.VFieldUI
 import org.kopi.galite.visual.ui.vaadin.base.BackgroundThreadHandler.access
 import org.kopi.galite.visual.ui.vaadin.field.BooleanField
-
-import com.vaadin.flow.component.AbstractField
-import com.vaadin.flow.component.HasValue
 
 /**
  * Boolean field.
@@ -36,14 +35,13 @@ import com.vaadin.flow.component.HasValue
  * @param detail is it a detail field view ?
  */
 class DBooleanField(
-        model: VFieldUI,
-        label: DLabel?,
-        align: Int,
-        options: Int,
-        detail: Boolean
-) : DObjectField(model, label, align, options, detail),
-        UTextField,
-        HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<org.kopi.galite.visual.ui.vaadin.field.AbstractField<Boolean?>, Boolean?>> {
+  model: VFieldUI,
+  label: DLabel?,
+  align: Int,
+  options: Int,
+  detail: Boolean
+) : DField(model, label, align, options, detail),
+    HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<org.kopi.galite.visual.ui.vaadin.field.AbstractField<Boolean?>, Boolean?>> {
 
   // --------------------------------------------------
   // DATA MEMBERS
@@ -56,15 +54,16 @@ class DBooleanField(
   // --------------------------------------------------
   init {
     field.addValueChangeListener(this)
-    field.addObjectFieldListener(this)
+    field.addBlurListener { gotoNextField() }
     setFieldContent(field)
   }
 
   // --------------------------------------------------
   // IMPLEMENTATION
   // --------------------------------------------------
-  override fun blinkOnFocus(): Boolean {
-    return false
+
+  override fun valueChanged() {
+    // Nothing to do
   }
 
   override fun updateColor() {
@@ -93,7 +92,6 @@ class DBooleanField(
     super.updateFocus()
   }
 
-
   override fun valueChanged(event: AbstractField.ComponentValueChangeEvent<org.kopi.galite.visual.ui.vaadin.field.AbstractField<Boolean?>, Boolean?>) {
     val text = getModel().toText(event.value)
 
@@ -115,40 +113,32 @@ class DBooleanField(
 
   override fun getObject(): Any? = wrappedField.value
 
-  override fun setBlink(b: Boolean) {
+  override fun setBlink(blink: Boolean) {
     access(currentUI) {
-      field.setBlink(b)
+      field.setBlink(blink)
     }
   }
 
   override fun getText(): String? = getModel().toText(field.value)
 
-  override fun setHasCriticalValue(b: Boolean) {}
-
-  override fun addSelectionFocusListener() {}
-
-  override fun removeSelectionFocusListener() {}
-
-  override fun setSelectionAfterUpdateDisabled(disable: Boolean) {}
-
   /**
    * Returns the true representation of this boolean field.
    * @return The true representation of this boolean field.
    */
-  internal val trueRepresentation: String?
+  private val trueRepresentation: String?
     get() = getModel().toText(true)
 
   /**
    * Returns the false representation of this boolean field.
    * @return The false representation of this boolean field.
    */
-  internal val falseRepresentation: String?
+  private val falseRepresentation: String?
     get() = getModel().toText(false)
 
   /**
    * Gets the focus to this field.
    */
-  internal fun enterMe() {
+  private fun enterMe() {
     access(currentUI) {
       field.setFocus(true)
     }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DBooleanField.kt
@@ -138,6 +138,8 @@ class DBooleanField(
 
   /**
    * Gets the focus to this field.
+   *
+   * @param focusOnFirst : Sets the focus on the first checkbox of the boolean field
    */
   private fun enterMe(focusOnFirst: Boolean) {
     access(currentUI) {

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
@@ -15,14 +15,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.kopi.galite.visual.ui.vaadin.form
 
-import org.kopi.galite.visual.form.UTextField
-import org.kopi.galite.visual.form.VConstants
-import org.kopi.galite.visual.form.VFieldUI
-import org.kopi.galite.visual.ui.vaadin.base.BackgroundThreadHandler.access
-import org.kopi.galite.visual.ui.vaadin.grid.GridEditorBooleanField
-import org.kopi.galite.visual.ui.vaadin.grid.GridEditorField
+package org.kopi.galite.visual.ui.vaadin.form
 
 import com.vaadin.flow.component.AbstractField
 import com.vaadin.flow.component.HasValue
@@ -31,18 +25,24 @@ import com.vaadin.flow.data.binder.ValueContext
 import com.vaadin.flow.data.converter.Converter
 import com.vaadin.flow.data.renderer.Renderer
 
+import org.kopi.galite.visual.form.VConstants
+import org.kopi.galite.visual.form.VFieldUI
+import org.kopi.galite.visual.ui.vaadin.base.BackgroundThreadHandler.access
+import org.kopi.galite.visual.ui.vaadin.grid.GridEditorBooleanField
+import org.kopi.galite.visual.ui.vaadin.grid.GridEditorField
+
 class DGridEditorBooleanField(
-        columnView: VFieldUI,
-        label: DGridEditorLabel?,
-        align: Int,
-        options: Int
+  columnView: VFieldUI,
+  label: DGridEditorLabel?,
+  align: Int,
+  options: Int
 ) : DGridEditorField<Boolean?>(columnView, label, align, options),
-      UTextField,
-        HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<GridEditorField<Boolean?>, Boolean?>> {
+    HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<GridEditorField<Boolean?>, Boolean?>> {
 
   //---------------------------------------------------
   // DATA MEMBERS
   //---------------------------------------------------
+
   private var inside = false
   private var rendrerValue: Boolean? = null
 
@@ -51,6 +51,8 @@ class DGridEditorBooleanField(
   //---------------------------------------------------
   init {
     editor.addValueChangeListener(this)
+    editor.addFocusListener {}
+    (editor as GridEditorBooleanField).addBlurListener { onGotoNextField() }
   }
 
   //---------------------------------------------------
@@ -89,13 +91,13 @@ class DGridEditorBooleanField(
 
   override fun updateAccess() {
     super.updateAccess()
+    label!!.update(columnView, getBlockView().getRecordFromDisplayLine(position))
     access {
-      // editor.setLabel(label.text) TODO
       (editor as GridEditorBooleanField).mandatory = getAccess() == VConstants.ACS_MUSTFILL
     }
   }
 
-  override fun getObject(): String? = getText()
+  override fun getObject(): String? = getModel().toText(editor.value)
 
   override fun createEditor(): GridEditorField<Boolean?> {
     return GridEditorBooleanField(trueRepresentation, falseRepresentation)
@@ -116,27 +118,11 @@ class DGridEditorBooleanField(
 
   override fun format(input: Any?): Any? {
     return when (input) {
-      true -> {
-        trueRepresentation
-      }
-      false -> {
-        falseRepresentation
-      }
-      else -> {
-        input
-      }
+      true -> trueRepresentation
+      false -> falseRepresentation
+      else -> input
     }
   }
-
-  override fun getText(): String? = getModel().toText(editor.value)
-
-  override fun setHasCriticalValue(b: Boolean) {}
-
-  override fun addSelectionFocusListener() {}
-
-  override fun removeSelectionFocusListener() {}
-
-  override fun setSelectionAfterUpdateDisabled(disable: Boolean) {}
 
   override fun valueChanged(event: AbstractField.ComponentValueChangeEvent<GridEditorField<Boolean?>, Boolean?>) {
     if (!event.isFromClient) {
@@ -163,22 +149,22 @@ class DGridEditorBooleanField(
    * Returns the true representation of this boolean field.
    * @return The true representation of this boolean field.
    */
-  internal val trueRepresentation: String?
+  private val trueRepresentation: String?
     get() = getModel().toText(true)
 
   /**
    * Returns the false representation of this boolean field.
    * @return The false representation of this boolean field.
    */
-  internal val falseRepresentation: String?
+  private val falseRepresentation: String?
     get() = getModel().toText(false)
 
   /**
    * Gets the focus to this field.
    */
-  internal fun enterMe() {
-    /*BackgroundThreadHandler.access(Runnable {  TODO
-      getEditor().focus()
-    })*/
+  private fun enterMe() {
+    access(currentUI) {
+      (editor as GridEditorBooleanField).setFocus(true)
+    }
   }
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
@@ -162,6 +162,8 @@ class DGridEditorBooleanField(
 
   /**
    * Gets the focus to this field.
+   *
+   * @param focusOnFirst : Sets the focus on the first checkbox of the boolean field
    */
   private fun enterMe(focusOnFirst: Boolean) {
     access(currentUI) {

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
@@ -25,6 +25,7 @@ import com.vaadin.flow.data.binder.ValueContext
 import com.vaadin.flow.data.converter.Converter
 import com.vaadin.flow.data.renderer.Renderer
 
+import org.kopi.galite.visual.form.VBooleanField
 import org.kopi.galite.visual.form.VConstants
 import org.kopi.galite.visual.form.VFieldUI
 import org.kopi.galite.visual.ui.vaadin.base.BackgroundThreadHandler.access
@@ -51,7 +52,6 @@ class DGridEditorBooleanField(
   //---------------------------------------------------
   init {
     editor.addValueChangeListener(this)
-    editor.addFocusListener {}
     (editor as GridEditorBooleanField).addKeyDownListener(gotoNext = { onGotoNextField() },
                                                           gotoPrevious = { onGotoPrevField() })
   }
@@ -74,7 +74,7 @@ class DGridEditorBooleanField(
     } else {
       if (!inside) {
         inside = true
-        enterMe()
+        enterMe((getModel() as? VBooleanField)?.focusOnFirst ?: true)
         if (rendrerValue != null) {
           getModel().isChangedUI = true
           getModel().setBoolean(getBlockView().model.activeRecord, rendrerValue)
@@ -163,9 +163,9 @@ class DGridEditorBooleanField(
   /**
    * Gets the focus to this field.
    */
-  private fun enterMe() {
+  private fun enterMe(focusOnFirst: Boolean) {
     access(currentUI) {
-      (editor as GridEditorBooleanField).setFocus(true)
+      (editor as GridEditorBooleanField).setFocus(true, focusOnFirst)
     }
   }
 }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/form/DGridEditorBooleanField.kt
@@ -52,7 +52,8 @@ class DGridEditorBooleanField(
   init {
     editor.addValueChangeListener(this)
     editor.addFocusListener {}
-    (editor as GridEditorBooleanField).addBlurListener { onGotoNextField() }
+    (editor as GridEditorBooleanField).addKeyDownListener(gotoNext = { onGotoNextField() },
+                                                          gotoPrevious = { onGotoPrevField() })
   }
 
   //---------------------------------------------------

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
@@ -162,7 +162,6 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
    */
   override fun getValue(): Boolean? = getBooleanValue(checkboxGroup.value)
 
-
   override fun doFocus() {
     checkboxGroup.focus()
   }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
@@ -48,6 +48,7 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
   var mandatory = false
   // Variable to keep track of the last focused checkbox item
   private var focusedIndex = 0
+  private var focusOnFirst = true
   // Initialize the field checkboxGroup Component
   private val checkboxGroup: FocusableCheckboxGroup<String> = FocusableCheckboxGroup<String>().apply {
     label = null
@@ -67,6 +68,7 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
       }
       // Update internal model and fire change event
       setModelValue(getBooleanValue(value), true)
+      (getChildren().toList().getOrNull(focusedIndex) as? Checkbox)?.focus()
     }
   }
 
@@ -86,8 +88,9 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
    * Sets the field focus.
    * @param focus The field focus
    */
-  fun setFocus(focus: Boolean) {
+  fun setFocus(focus: Boolean, focusOnFirst: Boolean) {
     if (focus) {
+      this.focusOnFirst = focusOnFirst
       focus()
     } else {
       blur()
@@ -104,13 +107,6 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
       selectedValues.contains(falseRepresentation) -> false
       else                                         -> null
     }
-  }
-
-  /**
-   * Function to check if the last item is currently focused
-   */
-  private fun isLastItemFocused(currentIndex: Int, itemCount: Int = 2): Boolean {
-    return currentIndex == itemCount
   }
 
   /**
@@ -166,19 +162,19 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
    */
   override fun getValue(): Boolean? = getBooleanValue(checkboxGroup.value)
 
+  /**
+   * Focus on the appropriate checkbox element
+   */
   override fun doFocus() {
-    checkboxGroup.focus()
+    focusedIndex = if (focusOnFirst) 0 else 1
+    val focusedCheckbox = checkboxGroup.getChildren().toList()[focusedIndex] as? Checkbox
+    focusedCheckbox?.focus()
   }
 
   /**
    * Adds Custom focus listener for BooleanField
    */
-  override fun addFocusListener(focusFunction: () -> Unit) {
-    checkboxGroup.element.addEventListener("focus") {
-      focusedIndex = 0
-      focusFunction()
-    }
-  }
+  override fun addFocusListener(focusFunction: () -> Unit) {}
 
   /**
    * Adds custom Key Down listener for BooleanField.
@@ -192,13 +188,13 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
           val modifier = event.modifiers.singleOrNull()
 
           if (modifier != null && modifier.name == "SHIFT") {
-            if (focusedIndex <= 1) { gotoPrevious() } else { focusedIndex-- }
+            if (focusedIndex <= 0) { gotoPrevious() } else { focusedIndex-- }
           } else {
-            if (isLastItemFocused(focusedIndex)) { gotoNext() } else { focusedIndex++ }
+            if (focusedIndex >= 1) { gotoNext() } else { focusedIndex++ }
           }
         }
         Key.ENTER, Key.SPACE -> { // Change the value of the currently focused checkbox
-          val checkbox = items.getOrNull(focusedIndex - 1) as? Checkbox
+          val checkbox = items.getOrNull(focusedIndex) as? Checkbox
 
           checkbox?.value = !(checkbox?.value ?: false)
         }

--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/grid/GridEditorBooleanField.kt
@@ -17,13 +17,17 @@
  */
 package org.kopi.galite.visual.ui.vaadin.grid
 
-import org.kopi.galite.visual.ui.vaadin.base.Styles
-import org.kopi.galite.visual.VColor
+import kotlin.streams.toList
 
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.Focusable
+import com.vaadin.flow.component.Key
 import com.vaadin.flow.component.KeyNotifier
+import com.vaadin.flow.component.checkbox.Checkbox
 import com.vaadin.flow.component.checkbox.CheckboxGroup
+
+import org.kopi.galite.visual.ui.vaadin.base.Styles
+import org.kopi.galite.visual.VColor
 
 /**
  * An editor for boolean field.
@@ -95,10 +99,10 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
    */
   private fun getBooleanValue(selectedValues: Set<String>): Boolean? {
     return when {
-      selectedValues.isEmpty()                    -> null
-      selectedValues.contains(trueRepresentation) -> true
+      selectedValues.isEmpty()                     -> null
+      selectedValues.contains(trueRepresentation)  -> true
       selectedValues.contains(falseRepresentation) -> false
-      else -> null
+      else                                         -> null
     }
   }
 
@@ -177,14 +181,27 @@ class GridEditorBooleanField(val trueRepresentation: String?,val falseRepresenta
   }
 
   /**
-   * Adds custom blur listener for BooleanField : the triggered function is only executed when leaving the field
+   * Adds custom Key Down listener for BooleanField.
    */
-  fun addBlurListener(function: () -> Unit) {
-    checkboxGroup.element.addEventListener("focusout") {
-      if (isLastItemFocused(focusedIndex)) {
-        function()
-      } else {
-        focusedIndex++
+  fun addKeyDownListener(gotoNext: () -> Unit, gotoPrevious: () -> Unit) {
+    checkboxGroup.addKeyDownListener { event ->
+      val items = checkboxGroup.getChildren().toList() // Retrieve child components (checkboxes)
+
+      when (event.key) {
+        Key.TAB -> {
+          val modifier = event.modifiers.singleOrNull()
+
+          if (modifier != null && modifier.name == "SHIFT") {
+            if (focusedIndex <= 1) { gotoPrevious() } else { focusedIndex-- }
+          } else {
+            if (isLastItemFocused(focusedIndex)) { gotoNext() } else { focusedIndex++ }
+          }
+        }
+        Key.ENTER, Key.SPACE -> { // Change the value of the currently focused checkbox
+          val checkbox = items.getOrNull(focusedIndex - 1) as? Checkbox
+
+          checkbox?.value = !(checkbox?.value ?: false)
+        }
       }
     }
   }

--- a/galite-core/src/main/resources/META-INF/resources/frontend/styles/galite/checkbox.css
+++ b/galite-core/src/main/resources/META-INF/resources/frontend/styles/galite/checkbox.css
@@ -16,10 +16,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/**
- * Boolean field style
+/*
+ * Boolean field style for CheckboxGroup
  */
-.true::part(checkbox), .false::part(checkbox) {
+.k-boolean-field vaadin-checkbox::part(checkbox) {
     width: 1em;
     height: 1em;
     border-radius: 50%;
@@ -27,45 +27,20 @@
     font-size: 14px !important;
 }
 
-.true::part(checkbox)::after, .false::part(checkbox)::after {
-    border-width: 0.3em 0 0 0.3em;
-    transform-origin: -1px -0.5px
-}
-
-.false::part(checkbox)::after {
-    opacity: none;
-    transform: none;
+.k-boolean-field vaadin-checkbox:nth-child(2)::part(checkbox)::after {
+    content: "✕"; /* Adds the 'x' mark to the second checkbox */
     font-size: 13px;
-    font-weight: bold;
     position: absolute;
     top: 0em;
     left: 0.09em;
-    box-sizing: border-box;
-    transform-origin: 0 0;
-    border-width: 0;
-    content: "\2715";
-    display: inline-block;
-    width: 0;
-    height: 0;
     color: white;
 }
 
-.multiple .k-boolean-field-content {
-    display: flex;
-    background-color: #ffffff;
-    align-items: center;
-    justify-content: center;
+.k-boolean-field-blink {
+  animation: blinkEffect 0.3s ease-in-out 2;
 }
 
-.editor-booleanfield, .k-boolean-field {
-    --lumo-primary-color: var(--background-color);
-}
-
-.k-boolean-field-content {
-    display: table;
-    border-bottom: 1px solid #dadada;
-}
-
-.k-boolean-field-content:focus-within {
-    border-bottom: 1px solid var(--background-color);
+@keyframes blinkEffect {
+  0%, 100% { background-color: inherit; }
+  50% { background-color: #ffdddd; }
 }

--- a/galite-core/src/main/resources/META-INF/resources/frontend/styles/galite/checkbox.css
+++ b/galite-core/src/main/resources/META-INF/resources/frontend/styles/galite/checkbox.css
@@ -30,6 +30,7 @@
 .k-boolean-field vaadin-checkbox:nth-child(2)::part(checkbox)::after {
     content: "✕"; /* Adds the 'x' mark to the second checkbox */
     font-size: 13px;
+    font-weight: bold;
     position: absolute;
     top: 0em;
     left: 0.09em;

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/client/ClientForm.kt
@@ -205,6 +205,9 @@ class ClientForm : DictionaryForm(title = "Clients", locale = Locale.UK) {
       help = "The item price"
       columns(P.price)
     }
+    val act = visit(domain = BOOL, position = at(2, 2)) {
+      label = "Active ?"
+    }
 
     init {
       border = Border.LINE

--- a/galite-demo/galite-vaadin/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/form/FormTests.kt
+++ b/galite-demo/galite-vaadin/src/test/kotlin/org/kopi/galite/tests/ui/vaadin/form/FormTests.kt
@@ -110,10 +110,10 @@ class FormTests: GaliteVUITestBase() {
     clientForm.list.triggerCommand()
     val block = clientForm.salesBlock.findMultiBlock()
     val data = arrayOf(
-      arrayOf("1".asDiv(), "1".asDiv(), "description Product 0".asDiv(), "1".asDiv(), "100,00000".asDiv()),
-      arrayOf("2".asDiv(), "2".asDiv(), "description Product 1".asDiv(), "1".asDiv(), "200,00000".asDiv()),
-      arrayOf("3".asDiv(), "3".asDiv(), "description Product 2".asDiv(), "2".asDiv(), "300,00000".asDiv()),
-      arrayOf("4".asDiv(), "4".asDiv(), "description Product 3".asDiv(), "3".asDiv(), "400,00000".asDiv())
+      arrayOf("1".asDiv(), "1".asDiv(), "description Product 0".asDiv(), "1".asDiv(), "100,00000".asDiv(), null.asDiv()),
+      arrayOf("2".asDiv(), "2".asDiv(), "description Product 1".asDiv(), "1".asDiv(), "200,00000".asDiv(), null.asDiv()),
+      arrayOf("3".asDiv(), "3".asDiv(), "description Product 2".asDiv(), "2".asDiv(), "300,00000".asDiv(), null.asDiv()),
+      arrayOf("4".asDiv(), "4".asDiv(), "description Product 3".asDiv(), "3".asDiv(), "400,00000".asDiv(), null.asDiv())
     )
 
     data.forEachIndexed { index, row ->


### PR DESCRIPTION
Use Vaadin flow CheckboxGroup component for Boolean field to simplify the field manipulation and fix the focus issues when using the keyboard to browse a form's different fields

This PR allows to shift the focus inside the checkbox group using the TAB key and to select / deselect the boolean field's values using the SPACE key.