### PR TITLE
Fix: Correct abnormal behavior of the list button and menu query in the ProductForm 

### DIFF
--- a/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/BackgroundThreadHandler.kt
+++ b/galite-core/src/main/kotlin/org/kopi/galite/visual/ui/vaadin/base/BackgroundThreadHandler.kt
@@ -139,6 +139,7 @@ object BackgroundThreadHandler {
    * @param command   The command which accesses the UI.
    */
   fun startAndWaitAndPush(lock: Object, currentUI: UI? = null, command: () -> Unit) {
+    Thread.sleep(50)
     accessAndPush(currentUI = currentUI, command = command)
 
     synchronized(lock) {

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/product/ProductForm.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/product/ProductForm.kt
@@ -52,28 +52,28 @@ class ProductForm : DictionaryForm(title = "Products", locale = Locale.UK) {
     val description = mustFill(domain = STRING(50), position = at(1, 1)) {
       label = "Description"
       help = "The product description"
-      columns(u.description){
+      columns(u.description) {
         priority = 4
       }
     }
     val price = mustFill(domain = DECIMAL(20, 10), follow(description)) {
       label = "Price"
       help = "The product unit price excluding VAT"
-      columns(u.price){
+      columns(u.price) {
         priority = 3
       }
     }
     val category = mustFill(domain = Category, position = at(2, 1)) {
       label = "Category"
       help = "The product category"
-      columns(u.category){
+      columns(u.category) {
         priority = 2
       }
     }
     val taxName = mustFill(domain = Tax, position = at(3, 1)) {
       label = "Tax"
       help = "The product tax name"
-      columns(u.taxName){
+      columns(u.taxName) {
         priority = 1
       }
     }

--- a/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/product/ProductForm.kt
+++ b/galite-demo/galite-vaadin/src/main/kotlin/org/kopi/galite/demo/product/ProductForm.kt
@@ -41,7 +41,7 @@ class ProductForm : DictionaryForm(title = "Products", locale = Locale.UK) {
 
   val block = page.insertBlock(BlockProduct())
 
-  inner class BlockProduct : Block("Products", 1, 1) {
+  inner class BlockProduct : Block("Products", 1, 100) {
     val u = table(Product, sequence = Sequence("PRODUCTS_SEQ"))
 
     val idPdt = hidden(domain = INT(20)) {
@@ -52,22 +52,30 @@ class ProductForm : DictionaryForm(title = "Products", locale = Locale.UK) {
     val description = mustFill(domain = STRING(50), position = at(1, 1)) {
       label = "Description"
       help = "The product description"
-      columns(u.description)
+      columns(u.description){
+        priority = 4
+      }
     }
     val price = mustFill(domain = DECIMAL(20, 10), follow(description)) {
       label = "Price"
       help = "The product unit price excluding VAT"
-      columns(u.price)
+      columns(u.price){
+        priority = 3
+      }
     }
     val category = mustFill(domain = Category, position = at(2, 1)) {
       label = "Category"
       help = "The product category"
-      columns(u.category)
+      columns(u.category){
+        priority = 2
+      }
     }
     val taxName = mustFill(domain = Tax, position = at(3, 1)) {
       label = "Tax"
       help = "The product tax name"
-      columns(u.taxName)
+      columns(u.taxName){
+        priority = 1
+      }
     }
     val photo = visit(domain = IMAGE(width = 100, height = 100), position = at(5, 1)) {
       label = "Image"


### PR DESCRIPTION
he issue is caused by event interference, which triggers a listener before the pop-up is displayed. To correct this, it is necessary to release the current thread for a few milliseconds to allow events to synchronize properly.

On the other hand, the display issue was caused by the **visible** parameter, which determines the number of lines to display. If it is less than 10, it adds a scroll to the pop-up. Therefore, I have set this parameter to 500 to maintain consistent behavior across similar projects (this parameter should ideally be managed automatically for lines greater than 10).

To address the two abnormal behaviors described in this task, we:

    Add a Thread.sleep(50) // Pause for 50 milliseconds to correct the behavior of the List button.
    Change the value of visible from 1 to 500 for the ProductForm.